### PR TITLE
DL-1118 - Raise Test (Statement) coverage within Cgt-calculator-resident-shares-frontend

### DIFF
--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -60,9 +60,9 @@ private object AppDependencies {
       override lazy val test = Seq(
         "uk.gov.hmrc" %% "hmrctest" % "3.9.0-play-26" % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % scope,
-        "org.mockito" % "mockito-core" % "3.1.0" % scope,
+        "org.mockito" % "mockito-core" % "3.2.0" % scope,
         "org.pegdown" % "pegdown" % "1.6.0" % scope,
-        "org.jsoup" % "jsoup" % "1.11.3" % scope,
+        "org.jsoup" % "jsoup" % "1.12.1" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
       )
     }.test

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -42,7 +42,7 @@ trait MicroService {
     import scoverage.ScoverageKeys
     Seq(
       // Semicolon-separated list of regexs matching classes to exclude
-      ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;.*AuthService.*;models\\.data\\..*;views.html.helpers.*;uk.gov.hmrc.BuildInfo;app.*;nr.*;res.*;prod.*;config.*;controllers.SessionCacheController",
+      ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;.*AuthService.*;models\\.data\\..*;views.html.helpers.*;uk.gov.hmrc.BuildInfo;app.*;nr.*;res.*;prod.*;config.*;controllers.SessionCacheController;testOnlyDoNotUseInAppConf.*",
       ScoverageKeys.coverageMinimum := 90,
       ScoverageKeys.coverageFailOnMinimum := false,
       ScoverageKeys.coverageHighlighting := true

--- a/test/common/DatesSpec.scala
+++ b/test/common/DatesSpec.scala
@@ -19,9 +19,13 @@ package common
 import uk.gov.hmrc.play.test.UnitSpec
 import java.time.LocalDate
 
+import common.Dates.TemplateImplicits.RichDate
 import common.Dates.formatter
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import play.api.i18n.{Lang, Messages}
 
-class DatesSpec extends UnitSpec {
+class DatesSpec extends UnitSpec with MockitoSugar {
 
   "Calling constructDate method" should {
 
@@ -83,6 +87,26 @@ class DatesSpec extends UnitSpec {
 
     "when called with 1999/4/5 return 1999 to 2000" in {
       Dates.taxYearOfDateLongHand(LocalDate.of(1999, 4, 5)) shouldBe "1998 to 1999"
+    }
+  }
+
+  "The RichDate wrapper class" should {
+
+    "format welsh dates accordingly" in {
+
+      val localDate = LocalDate.parse("2014-04-05")
+      val richDate: RichDate = new Dates.TemplateImplicits.RichDate(localDate)
+      val monthWelshTranslation = "test-month"
+
+      val mockLanguage = mock[Lang]
+      val mockMessages = mock[Messages]
+
+      when(mockLanguage.language) thenReturn "cy"
+      when(mockMessages.apply(s"calc.month.${localDate.getMonthValue}")) thenReturn monthWelshTranslation
+
+      val localFormatString = richDate.localFormat("")(mockLanguage, mockMessages)
+
+      localFormatString shouldBe localDate.getDayOfMonth + " " + monthWelshTranslation + " " + localDate.getYear
     }
   }
 }

--- a/test/common/TransformersSpec.scala
+++ b/test/common/TransformersSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.util.Random
+
+class TransformersSpec extends UnitSpec {
+
+  val nonNumericString = "non-numeric"
+
+  "The Transformers object" when {
+
+    "Converting a String to a BigDecimal" should {
+
+      "successfully parse a valid string to a BigDecimal value" in {
+
+        val randomDouble: Double = Random.nextDouble
+
+        Transformers.stringToBigDecimal(randomDouble.toString) shouldBe BigDecimal(randomDouble)
+      }
+
+      "produce BigDecimal(0) if an invalid string is passed to it" in {
+
+        Transformers.stringToBigDecimal(nonNumericString) shouldBe BigDecimal(0)
+      }
+    }
+
+    "Converting a BigDecimal to a String" should {
+
+      "pad BigDecimals to 2 decimal places if they only have 1" in {
+
+        val bigDecimal = BigDecimal(1234.5)
+
+        Transformers.bigDecimalToString(bigDecimal) shouldBe bigDecimal.setScale(2).toString
+      }
+
+      "call .toString on BigDecimals that don't have 1 decimal place" in {
+
+        val bigDecimalNoDecimalPlaces = BigDecimal(1234)
+        val bigDecimalSomeDecimalPlaces = BigDecimal(1234.56789)
+
+        Transformers.bigDecimalToString(bigDecimalNoDecimalPlaces) shouldBe bigDecimalNoDecimalPlaces.toString
+        Transformers.bigDecimalToString(bigDecimalSomeDecimalPlaces) shouldBe bigDecimalSomeDecimalPlaces.toString
+      }
+    }
+
+    "Converting a String to an Integer" should {
+
+      "produce 0 if an invalid string is passed to it" in {
+
+        Transformers.stringToInteger(nonNumericString) shouldBe 0
+      }
+    }
+  }
+}

--- a/test/common/ValidationSpec.scala
+++ b/test/common/ValidationSpec.scala
@@ -19,7 +19,7 @@ package common
 import java.time.LocalDate
 
 import common.Validation._
-import play.api.data.validation.{Invalid, Valid, ValidationError}
+import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
 import uk.gov.hmrc.play.test.UnitSpec
 
 class ValidationSpec extends UnitSpec {
@@ -375,5 +375,32 @@ class ValidationSpec extends UnitSpec {
         }
     }
 
+  "The max monetary value constraint" should {
+
+    val maxValue: BigDecimal = 3000
+    val extractMoney: BigDecimal => Option[BigDecimal] = money  => Some(money)
+
+    "return invalid if given an amount of money more than the max" in {
+
+      val result = maxMonetaryValueConstraint(maxValue, extractMoney)(maxValue + 1).getClass
+
+      result shouldBe classOf[Invalid]
+    }
+
+    "return valid if given an amount of money less than the max" in {
+
+      val result = maxMonetaryValueConstraint(maxValue, extractMoney)(maxValue - 1)
+
+      result shouldBe Valid
+    }
+
+    "return valid if given an amount that results in None" in {
+
+      val extractMoneyNone: BigDecimal => Option[BigDecimal] = _ => None
+      val result = maxMonetaryValueConstraint(maxValue, extractMoneyNone)(maxValue)
+
+      result shouldBe Valid
+    }
+  }
 
 }

--- a/test/common/YesNoKeysSpec.scala
+++ b/test/common/YesNoKeysSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import uk.gov.hmrc.play.test.UnitSpec
+
+class YesNoKeysSpec extends UnitSpec {
+
+  "the yes key" should {
+
+    "be equal to 'Yes'" in {
+
+      YesNoKeys.yes shouldBe "Yes"
+    }
+  }
+
+  "the no key" should {
+
+    "be equal to 'No'" in {
+
+      YesNoKeys.no shouldBe "No"
+    }
+  }
+}

--- a/test/common/resident/HowYouBecameTheOwnerKeysSpec.scala
+++ b/test/common/resident/HowYouBecameTheOwnerKeysSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common.resident
+
+import uk.gov.hmrc.play.test.UnitSpec
+
+class HowYouBecameTheOwnerKeysSpec extends UnitSpec {
+
+  "the inheritedIt key" should {
+
+    "be equal to 'Inherited'" in {
+
+      HowYouBecameTheOwnerKeys.inheritedIt shouldBe "Inherited"
+    }
+  }
+
+  "the boughtIt key" should {
+
+    "be equal to 'Bought'" in {
+
+      HowYouBecameTheOwnerKeys.boughtIt shouldBe "Bought"
+    }
+  }
+
+  "the giftedIt key" should {
+
+    "be equal to 'Gifted'" in {
+
+      HowYouBecameTheOwnerKeys.giftedIt shouldBe "Gifted"
+    }
+  }
+}

--- a/test/controllers/CgtLanguageControllerSpec.scala
+++ b/test/controllers/CgtLanguageControllerSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.ApplicationConfig
+import controllers.helpers.FakeRequestHelper
+import org.scalatest.mockito.MockitoSugar
+import play.api.http.FileMimeTypes
+import play.api.i18n.{Lang, Langs, MessagesApi}
+import play.api.mvc._
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+import scala.concurrent.ExecutionContext
+
+class CgtLanguageControllerSpec extends UnitSpec with FakeRequestHelper with MockitoSugar with WithFakeApplication {
+
+  val mockMCC: MessagesControllerComponents = new MessagesControllerComponents {
+
+    private val mcc = fakeApplication.injector.instanceOf[MessagesControllerComponents]
+
+    override def messagesActionBuilder: MessagesActionBuilder = mcc.messagesActionBuilder
+
+    override def actionBuilder: ActionBuilder[Request, AnyContent] = mcc.actionBuilder
+
+    override def parsers: PlayBodyParsers = mcc.parsers
+
+    override def messagesApi: MessagesApi = mcc.messagesApi
+
+    override def langs: Langs = new Langs {
+
+      override def availables: Seq[Lang] = mcc.langs.availables
+
+      override def preferred(candidates: Seq[Lang]): Lang = mcc.langs.availables.head
+    }
+
+    override def fileMimeTypes: FileMimeTypes = mcc.fileMimeTypes
+
+    override def executionContext: ExecutionContext = mcc.executionContext
+  }
+
+  "The CgtLanguageController" when {
+
+    "the language is switched to english" should {
+
+      val mockConfig: ApplicationConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+      val cgtLanguageController = new CgtLanguageController(mockMCC, mockConfig)
+
+      "use the fallback URL when there's no referrer in the request header" in {
+
+        val result = cgtLanguageController.switchToLanguage("english")(fakeRequest)
+        status(result) shouldBe 303
+      }
+    }
+  }
+
+}

--- a/test/controllers/FeedbackSurveyControllerSpec.scala
+++ b/test/controllers/FeedbackSurveyControllerSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.ApplicationConfig
+import controllers.helpers.FakeRequestHelper
+import org.scalatest.mockito.MockitoSugar
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+class FeedbackSurveyControllerSpec extends UnitSpec with FakeRequestHelper with MockitoSugar with WithFakeApplication {
+
+  implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
+
+  val feedbackSurveyController = new FeedbackSurveyController(mockConfig, mockMCC)
+
+  "The FeedbackSurveyController" when {
+
+    "redirecting to the feedback survey" should {
+
+      "successfully redirect to the feedback survey" in {
+
+        val result = feedbackSurveyController.redirectExitSurvey(fakeRequest)
+        status(result) shouldBe 303
+      }
+    }
+  }
+}

--- a/test/forms/PersonalAllowanceFormSpec.scala
+++ b/test/forms/PersonalAllowanceFormSpec.scala
@@ -104,5 +104,23 @@ class PersonalAllowanceFormSpec extends UnitSpec with WithFakeApplication with F
                 form.error("amount").get.message shouldBe "calc.common.error.maxAmountExceeded"
            }
           }
+
+    "The max personal allowance validation" should {
+
+      val maxPersonalAllowance: BigDecimal = BigDecimal(8000)
+      val greaterThanMaxPersonalAllowance = maxPersonalAllowance + 1
+      val lessThanMaxPersonalAllowance = maxPersonalAllowance - 1
+      val validateMaxPaTest = validateMaxPA(maxPersonalAllowance)
+
+      "evaluate as false when passed a value that's greater than the max personal allowance" in {
+
+        validateMaxPaTest(greaterThanMaxPersonalAllowance) shouldBe false
+      }
+
+      "evaluate as true when passed a value that's less than the max personal allowance" in {
+
+        validateMaxPaTest(lessThanMaxPersonalAllowance) shouldBe true
+      }
+    }
   }
 }

--- a/test/views/ErrorTemplateViewSpec.scala
+++ b/test/views/ErrorTemplateViewSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import config.ApplicationConfig
+import controllers.helpers.FakeRequestHelper
+import org.scalatest.mockito.MockitoSugar
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import views.{html => views}
+
+class ErrorTemplateViewSpec extends UnitSpec with FakeRequestHelper with MockitoSugar with WithFakeApplication {
+
+  lazy val mockAppConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  lazy val mockMessages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+
+  val pageTitle = ""
+  val heading = ""
+  val message = ""
+  val homeNavLink = ""
+
+  "Error Template view" should {
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = (views.error_template.f(pageTitle, heading, message, homeNavLink)
+      (fakeRequest, mockMessages, fakeApplication, mockAppConfig))
+
+      val render = views.error_template.render(pageTitle, heading, message, homeNavLink,
+        fakeRequest, mockMessages, fakeApplication, mockAppConfig)
+
+      f shouldBe render
+    }
+  }
+}

--- a/test/views/GovWrapperViewSpec.scala
+++ b/test/views/GovWrapperViewSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import config.ApplicationConfig
+import controllers.helpers.FakeRequestHelper
+import org.scalatest.mockito.MockitoSugar
+import play.api.i18n.Messages
+import play.api.mvc.MessagesControllerComponents
+import play.twirl.api.Html
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import views.html.govuk_wrapper
+
+class GovWrapperViewSpec extends UnitSpec with FakeRequestHelper with MockitoSugar with WithFakeApplication {
+
+  lazy val applicationConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  lazy val messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+
+  val title = "title"
+  val mainClass = None
+  val mainDataAttributes = None
+  val bodyClasses = None
+  val sidebar = Html("")
+  val contentHeader = None
+  val mainContent = Html("")
+  val serviceInfoContent = Html("")
+  val scriptElem = None
+  val afterHeader = Html("")
+  val homeLink = ""
+  val navTitle = ""
+
+  ".render and .f" should {
+
+    "both generate identical templates" in {
+
+      val render = govuk_wrapper.render(applicationConfig, title, mainClass, mainDataAttributes, bodyClasses, sidebar, contentHeader,
+        mainContent, serviceInfoContent, scriptElem, afterHeader, homeLink, navTitle, fakeRequest, messages)
+
+      val f = govuk_wrapper.f(applicationConfig, title, mainClass, mainDataAttributes, bodyClasses, sidebar, contentHeader,
+        mainContent, serviceInfoContent, scriptElem, afterHeader, homeLink, navTitle)(fakeRequest, messages)
+
+      f shouldBe render
+    }
+  }
+}

--- a/test/views/calculation/LanguageSelectionViewSpec.scala
+++ b/test/views/calculation/LanguageSelectionViewSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.calculation
+
+import config.ApplicationConfig
+import controllers.helpers.FakeRequestHelper
+import org.scalatest.mockito.MockitoSugar
+import play.api.i18n.{Lang, Messages}
+import play.api.mvc.{Call, MessagesControllerComponents}
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import views.html.{calculation => views}
+
+class LanguageSelectionViewSpec extends UnitSpec with FakeRequestHelper with MockitoSugar with WithFakeApplication {
+
+  val appConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  val messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+
+  val langMap: Map[String, Lang] = Map.empty
+  val langToCall: String => Call =_ => Call("", "")
+  val customClass: Option[String] = None
+  val appName: Option[String] = None
+
+  "Language selection view" should {
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.language_selection.f(langMap, langToCall, customClass, appName)(messages)
+
+      val render = views.language_selection.render(langMap, langToCall, customClass, appName, messages)
+
+      f shouldBe render
+    }
+  }
+}

--- a/test/views/calculation/OutsideTaxYearsViewSpec.scala
+++ b/test/views/calculation/OutsideTaxYearsViewSpec.scala
@@ -79,6 +79,17 @@ class OutsideTaxYearsViewSpec extends UnitSpec with WithFakeApplication with Fak
           backLink.attr("href") shouldBe "back-link"
         }
       }
+
+      "generate the same template when .render and .f are called" in {
+
+        val f = views.outsideTaxYear.f(taxYear, false, true, "back-link", "home-link", "continue-link",
+          "navTitle")(fakeRequestWithSession, mockMessage, fakeApplication, mockConfig)
+
+        val render = views.outsideTaxYear.render(taxYear, false, true, "back-link", "home-link", "continue-link",
+          "navTitle", fakeRequestWithSession, mockMessage, fakeApplication, mockConfig)
+
+        f shouldBe render
+      }
     }
 
     "using a disposal date after 2016/17" should {

--- a/test/views/calculation/ResidentMainTemplateViewSpec.scala
+++ b/test/views/calculation/ResidentMainTemplateViewSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.calculation
+
+import config.ApplicationConfig
+import views.html.{calculation => views}
+import controllers.helpers.FakeRequestHelper
+import org.scalatest.mockito.MockitoSugar
+import play.api.i18n.Messages
+import play.api.mvc.MessagesControllerComponents
+import play.twirl.api.Html
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+class ResidentMainTemplateViewSpec extends UnitSpec with FakeRequestHelper with MockitoSugar with WithFakeApplication {
+
+  lazy val messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+  lazy val applicationConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+
+  val title = ""
+  val sidebarLinks: Option[Html] = None
+  val contentHeader: Option[Html] = None
+  val bodyClasses: Option[String] = None
+  val mainClass: Option[String] = None
+  val scriptElem: Option[Html] = None
+  val isUserResearchBannerVisible = false
+  val articleLayout = true
+  val backLink: Option[String] = None
+  val homeLink = ""
+  val navTitle = ""
+  val mainContent = Html("")
+
+  "Resident shares template view" should {
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.resident_main_template.f(title, sidebarLinks, contentHeader, bodyClasses, mainClass, scriptElem,
+        isUserResearchBannerVisible, articleLayout, backLink, homeLink, navTitle)(mainContent)(fakeRequest,
+        messages, fakeApplication, applicationConfig)
+
+      val render = views.resident_main_template.render(title, sidebarLinks, contentHeader, bodyClasses, mainClass, scriptElem,
+        isUserResearchBannerVisible, articleLayout, backLink, homeLink, navTitle, mainContent, fakeRequest,
+        messages, fakeApplication, applicationConfig)
+
+      f shouldBe render
+    }
+  }
+}

--- a/test/views/calculation/checkYourAnswers/CheckYourAnswersViewSpec.scala
+++ b/test/views/calculation/checkYourAnswers/CheckYourAnswersViewSpec.scala
@@ -108,5 +108,21 @@ class CheckYourAnswersViewSpec extends UnitSpec with WithFakeApplication with Fa
       continueButton.hasClass("button") shouldBe true
     }
   }
+
+  "CheckYourAnswers view" should {
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = (views.checkYourAnswers.f(dummyPostCall, dummyBackLink, gainAnswersMostPossibles,
+        Some(deductionAnswersMostPossibles), Some(taxYearModel), Some(incomeAnswers), false)
+        (fakeRequestWithSession,mockMessage, fakeApplication, fakeLang, mockConfig))
+
+      val render = views.checkYourAnswers.render(dummyPostCall, dummyBackLink, gainAnswersMostPossibles,
+        Some(deductionAnswersMostPossibles), Some(taxYearModel), Some(incomeAnswers), false,
+      fakeRequestWithSession,mockMessage, fakeApplication, fakeLang, mockConfig)
+
+      f shouldBe render
+    }
+  }
 }
 

--- a/test/views/calculation/deductions/LossesBroughtForwardValueViewSpec.scala
+++ b/test/views/calculation/deductions/LossesBroughtForwardValueViewSpec.scala
@@ -150,6 +150,19 @@ class LossesBroughtForwardValueViewSpec extends UnitSpec with WithFakeApplicatio
           }
         }
       }
+
+      "generate the same template when .render and .f are called" in {
+
+        val f = views.lossesBroughtForwardValue.f(lossesBroughtForwardValueForm, taxYear, "back-link",
+          "home-link", controllers.routes.DeductionsController.submitLossesBroughtForwardValue(), "navTitle")(fakeRequest,
+          mockMessage, fakeApplication, mockConfig)
+
+        val render = views.lossesBroughtForwardValue.render(lossesBroughtForwardValueForm, taxYear, "back-link",
+          "home-link", controllers.routes.DeductionsController.submitLossesBroughtForwardValue(), "navTitle",
+          fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+        f shouldBe render
+      }
     }
 
     "provided with a date in the 2014/15 tax year" should {

--- a/test/views/calculation/deductions/LossesBroughtForwardViewSpec.scala
+++ b/test/views/calculation/deductions/LossesBroughtForwardViewSpec.scala
@@ -95,6 +95,17 @@ class LossesBroughtForwardViewSpec extends UnitSpec with WithFakeApplication wit
     "have a continue button " in {
       doc.body.getElementById("continue-button").text shouldEqual commonMessages.continue
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.lossesBroughtForward.f(lossesBroughtForwardForm, postAction, "", TaxYearModel("2015/16", true, "2015/16"),
+        "home-link", "navTitle")(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.lossesBroughtForward.render(lossesBroughtForwardForm, postAction, "", TaxYearModel("2015/16", true, "2015/16"),
+        "home-link", "navTitle", fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 
   "Losses Brought Forward view with pre-selected value of yes" should {

--- a/test/views/calculation/gain/AcquisitionCostsViewSpec.scala
+++ b/test/views/calculation/gain/AcquisitionCostsViewSpec.scala
@@ -157,6 +157,16 @@ class AcquisitionCostsViewSpec extends UnitSpec with WithFakeApplication with Fa
       }
 
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val render = views.acquisitionCosts.render(acquisitionCostsForm, Some("back-link"), "home-link", fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val f = views.acquisitionCosts.f(acquisitionCostsForm, Some("back-link"), "home-link")(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+
+      f shouldBe render
+    }
   }
 
   "Acquisition Costs shares view with form with errors" which {

--- a/test/views/calculation/gain/AcquisitionValueViewSpec.scala
+++ b/test/views/calculation/gain/AcquisitionValueViewSpec.scala
@@ -150,6 +150,15 @@ class AcquisitionValueViewSpec extends UnitSpec with WithFakeApplication with Fa
         }
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.acquisitionValue.f(acquisitionValueForm, "home-link")(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.acquisitionValue.render(acquisitionValueForm, "home-link", fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 
   "Acquisition Value View with form with errors" should {

--- a/test/views/calculation/gain/DidYouInheritThemViewSpec.scala
+++ b/test/views/calculation/gain/DidYouInheritThemViewSpec.scala
@@ -214,6 +214,15 @@ class DidYouInheritThemViewSpec extends UnitSpec with WithFakeApplication with F
         button.text shouldEqual s"${commonMessages.continue}"
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.didYouInheritThem.f(didYouInheritThemForm)(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.didYouInheritThem.render(didYouInheritThemForm, fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 
   "Sell for less view with a filled form" which {

--- a/test/views/calculation/gain/DisposalCostsViewSpec.scala
+++ b/test/views/calculation/gain/DisposalCostsViewSpec.scala
@@ -158,6 +158,16 @@ class DisposalCostsViewSpec extends UnitSpec with WithFakeApplication with FakeR
       }
 
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.disposalCosts.f(disposalCostsForm, "home-link")(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.disposalCosts.render(disposalCostsForm, "home-link", fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
+
   }
 
   "Disposal Costs View with form with errors" which {

--- a/test/views/calculation/gain/DisposalDateViewSpec.scala
+++ b/test/views/calculation/gain/DisposalDateViewSpec.scala
@@ -75,6 +75,18 @@ class DisposalDateViewSpec extends UnitSpec with WithFakeApplication with FakeRe
     "have a button with the text 'Continue'" in {
       doc.body.getElementById("continue-button").text shouldBe commonMessages.continue
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = (views.disposalDate.f(disposalDateForm(
+        LocalDate.parse("2015-04-06").atStartOfDay(ZoneId.of("Europe/London"))), "home-link")
+      (fakeRequest, mockMessage, fakeApplication, mockConfig))
+
+      val render = views.disposalDate.render(disposalDateForm(LocalDate.parse("2015-04-06").atStartOfDay(ZoneId.of("Europe/London"))), "home-link",
+        fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 
   "Disposal Date view with a pre-filled form" should {

--- a/test/views/calculation/gain/DisposalValueViewSpec.scala
+++ b/test/views/calculation/gain/DisposalValueViewSpec.scala
@@ -84,6 +84,16 @@ class DisposalValueViewSpec extends UnitSpec with WithFakeApplication with FakeR
     "have the joint ownership text" in {
       doc.select("p.panel-indent").text shouldBe messages.jointOwnership
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.disposalValue.f(disposalValueForm, "home-link")(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.disposalValue.render(disposalValueForm, "home-link", fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
+
   }
 
   "Disposal Value View with form without errors" should {

--- a/test/views/calculation/gain/OwnerBeforeLegislationStartViewSpec.scala
+++ b/test/views/calculation/gain/OwnerBeforeLegislationStartViewSpec.scala
@@ -212,6 +212,17 @@ class OwnerBeforeLegislationStartViewSpec extends UnitSpec with WithFakeApplicat
         button.text shouldEqual s"${commonMessages.continue}"
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.ownerBeforeLegislationStart.f(ownerBeforeLegislationStartForm, "home-link", Some("back-link"))(fakeRequest,
+        mockMessage, fakeApplication, mockConfig)
+
+      val render = views.ownerBeforeLegislationStart.render(ownerBeforeLegislationStartForm, "home-link", Some("back-link"), fakeRequest,
+        mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 
   "Owned Before 1982 view with a filled form" which {

--- a/test/views/calculation/gain/ResidentSharesMainTemplateViewSpec.scala
+++ b/test/views/calculation/gain/ResidentSharesMainTemplateViewSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.calculation.gain
+
+import config.ApplicationConfig
+import controllers.helpers.FakeRequestHelper
+import org.scalatest.mockito.MockitoSugar
+import play.api.i18n.Messages
+import play.api.mvc.MessagesControllerComponents
+import play.twirl.api.Html
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import views.html.calculation.{gain => views}
+
+class ResidentSharesMainTemplateViewSpec extends UnitSpec with FakeRequestHelper with MockitoSugar with WithFakeApplication {
+
+  val appConfig: ApplicationConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  val messages: Messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+
+  val title: String = ""
+  val sidebarLinks: Option[Html] = None
+  val contentHeader: Option[Html] = None
+  val bodyClasses: Option[String] = None
+  val mainClass: Option[String] = None
+  val scriptElem: Option[Html] = None
+  val articleLayout: Boolean = true
+  val backLink: Option[String] = None
+  val mainContent: Html = Html("")
+
+  "Resident shares main template view" should {
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.resident_shares_main_template.f(title, sidebarLinks, contentHeader, bodyClasses, mainClass, scriptElem,
+        articleLayout, backLink)(mainContent)(fakeRequest, messages, fakeApplication, appConfig)
+
+      val render = views.resident_shares_main_template.render(title, sidebarLinks, contentHeader, bodyClasses, mainClass, scriptElem,
+        articleLayout, backLink, mainContent, fakeRequest, messages, fakeApplication, appConfig)
+
+      f shouldBe render
+    }
+  }
+}

--- a/test/views/calculation/gain/SellForLessViewSpec.scala
+++ b/test/views/calculation/gain/SellForLessViewSpec.scala
@@ -214,6 +214,15 @@ class SellForLessViewSpec extends UnitSpec with WithFakeApplication with FakeReq
         button.text shouldEqual s"${commonMessages.continue}"
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.sellForLess.f(sellForLessForm, "home-link", "back-link")(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.sellForLess.render(sellForLessForm, "home-link", "back-link", fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 
   "Sell for less view with a filled form" which {

--- a/test/views/calculation/gain/ValueBeforeLegislationStartViewSpec.scala
+++ b/test/views/calculation/gain/ValueBeforeLegislationStartViewSpec.scala
@@ -138,6 +138,15 @@ class ValueBeforeLegislationStartViewSpec extends UnitSpec with WithFakeApplicat
         }
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.valueBeforeLegislationStart.f(valueBeforeLegislationStartForm)(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.valueBeforeLegislationStart.render(valueBeforeLegislationStartForm, fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 
   "ValueBeforeLegislationStart View with form without errors" should {

--- a/test/views/calculation/gain/WorthWhenInheritedViewSpec.scala
+++ b/test/views/calculation/gain/WorthWhenInheritedViewSpec.scala
@@ -97,7 +97,17 @@ class WorthWhenInheritedViewSpec extends UnitSpec with WithFakeApplication with 
     "have a continue button " in {
       doc.select("#continue-button").text shouldBe commonMessages.continue
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.worthWhenInherited.f(form)(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.worthWhenInherited.render(form, fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
+
 
   "worthWhenInherited View with form without errors" should {
     lazy val form = worthWhenInheritedForm.bind(Map("amount" -> "100"))

--- a/test/views/calculation/gain/WorthWhenSoldForLessViewSpec.scala
+++ b/test/views/calculation/gain/WorthWhenSoldForLessViewSpec.scala
@@ -141,6 +141,15 @@ class WorthWhenSoldForLessViewSpec extends UnitSpec with WithFakeApplication wit
         }
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.worthWhenSoldForLess.f(worthWhenSoldForLessForm, "home-link")(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.worthWhenSoldForLess.render(worthWhenSoldForLessForm, "home-link", fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 
   "The Shares Worth When Sold For Less View when supplied with a correct form" should {

--- a/test/views/calculation/income/CurrentIncomeViewSpec.scala
+++ b/test/views/calculation/income/CurrentIncomeViewSpec.scala
@@ -138,6 +138,15 @@ class CurrentIncomeViewSpec extends UnitSpec with WithFakeApplication with FakeR
         }
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.currentIncome.f(currentIncomeForm, backLink, taxYearModel, false)(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.currentIncome.render(currentIncomeForm, backLink, taxYearModel, false, fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 
   "The Current Income View with form with errors" which {

--- a/test/views/calculation/income/PersonalAllowanceViewSpec.scala
+++ b/test/views/calculation/income/PersonalAllowanceViewSpec.scala
@@ -175,6 +175,18 @@ class PersonalAllowanceViewSpec extends UnitSpec with WithFakeApplication with F
           input.`val` shouldBe "1000"
         }
       }
+
+      "generate the same template when .render and .f are called" in {
+
+        val f = views.personalAllowance.f(personalAllowanceForm(), taxYearModel, BigDecimal(10600), "home", postAction,
+          Some("back-link"), JourneyKeys.shares, "navTitle", Dates.getCurrentTaxYear)(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+        val render = views.personalAllowance.render(personalAllowanceForm(), taxYearModel, BigDecimal(10600), "home", postAction,
+          Some("back-link"), JourneyKeys.shares, "navTitle", Dates.getCurrentTaxYear, fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+        f shouldBe render
+      }
+
     }
 
     "supplied with the current tax year" should {

--- a/test/views/calculation/report/SharesDeductionsReportViewSpec.scala
+++ b/test/views/calculation/report/SharesDeductionsReportViewSpec.scala
@@ -166,5 +166,17 @@ class SharesDeductionsReportViewSpec extends UnitSpec with WithFakeApplication w
     "does not display the section for what to do next" in {
       doc.select("#whatToDoNext").isEmpty shouldBe true
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val render = views.deductionsSummaryReport.render(gainAnswers, deductionAnswers, results, taxYearModel, 1000,
+        fakeRequestWithSession, mockMessage, fakeApplication, fakeLang)
+
+      val f = views.deductionsSummaryReport.f(gainAnswers, deductionAnswers, results, taxYearModel, 1000)(
+        fakeRequestWithSession, mockMessage, fakeApplication, fakeLang)
+
+      f shouldBe render
+    }
   }
+
 }

--- a/test/views/calculation/report/SharesFinalReportViewSpec.scala
+++ b/test/views/calculation/report/SharesFinalReportViewSpec.scala
@@ -101,8 +101,21 @@ class SharesFinalReportViewSpec extends UnitSpec with WithFakeApplication with F
 
       "have a calculation detail section" in {
         doc.select("#calcDetails").size() shouldBe 1
-      }}
+      }
+
+      "generate the same template when .render and .f are called" in {
+
+        val f = views.finalSummaryReport.f(gainAnswers, deductionAnswers, incomeAnswers, results, taxYearModel,
+          false, 100, 100)(fakeRequestWithSession, mockMessage, fakeApplication, fakeLang)
+
+        val render = views.finalSummaryReport.render(gainAnswers, deductionAnswers, incomeAnswers, results, taxYearModel,
+          false, 100, 100, fakeRequestWithSession, mockMessage, fakeApplication, fakeLang)
+
+        f shouldBe render
+      }
+
     }
+  }
 
 
   "Final Summary when supplied with a date above the known tax years" should {

--- a/test/views/calculation/report/SharesGainReportViewSpec.scala
+++ b/test/views/calculation/report/SharesGainReportViewSpec.scala
@@ -90,6 +90,15 @@ class SharesGainReportViewSpec extends UnitSpec with WithFakeApplication with Fa
           doc.select("#personalAllowance-question").size() shouldBe 0
         }
       }
+
+      "generate the same template when .render and .f are called" in {
+
+        val f = views.gainSummaryReport.f(testModel, -2000, taxYearModel, 1000)(fakeRequest, mockMessage, fakeApplication, fakeLang)
+
+        val render = views.gainSummaryReport.render(testModel, -2000, taxYearModel, 1000, fakeRequest, mockMessage, fakeApplication, fakeLang)
+
+        f shouldBe render
+      }
     }
   }
 

--- a/test/views/calculation/summary/SharesDeductionsSummaryViewSpec.scala
+++ b/test/views/calculation/summary/SharesDeductionsSummaryViewSpec.scala
@@ -186,6 +186,16 @@ class SharesDeductionsSummaryViewSpec extends UnitSpec with WithFakeApplication 
 
     }
 
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.deductionsSummary.f(gainAnswers, deductionAnswers, results, backUrl,
+        taxYearModel, "home-link", 100, true)(fakeRequestWithSession, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.deductionsSummary.render(gainAnswers, deductionAnswers, results, backUrl,
+        taxYearModel, "home-link", 100, true, fakeRequestWithSession, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 
   "Properties Deductions Summary view when a tax year outside the accepted is supplied" should {
@@ -240,4 +250,6 @@ class SharesDeductionsSummaryViewSpec extends UnitSpec with WithFakeApplication 
       doc.select("div#ur-panel").size() shouldBe 0
     }
   }
+
+
 }

--- a/test/views/calculation/summary/SharesFinalSummaryViewSpec.scala
+++ b/test/views/calculation/summary/SharesFinalSummaryViewSpec.scala
@@ -455,6 +455,17 @@ class SharesFinalSummaryViewSpec extends UnitSpec with WithFakeApplication with 
 
         }
       }
+
+      "generate the same template when .render and .f are called" in {
+
+        val f = views.finalSummary.f(gainAnswers, deductionAnswers, results, backLinkUrl, taxYearModel, "", 100, 100,
+          true)(fakeRequestWithSession, mockMessage, fakeApplication, mockConfig)
+
+        val render = views.finalSummary.render(gainAnswers, deductionAnswers, results, backLinkUrl, taxYearModel, "", 100, 100,
+          true, fakeRequestWithSession, mockMessage, fakeApplication, mockConfig)
+
+        f shouldBe render
+      }
     }
 
     "the share was sold outside tax years" should {

--- a/test/views/calculation/summary/SharesGainSummaryViewSpec.scala
+++ b/test/views/calculation/summary/SharesGainSummaryViewSpec.scala
@@ -396,6 +396,16 @@ class SharesGainSummaryViewSpec extends UnitSpec with WithFakeApplication with F
 
       }
 
+      "generate the same template when .render and .f are called" in {
+
+        val f = views.gainSummary.f(testModel, -100, taxYearModel, "home-link", 150 , 11000,
+          true)(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+        val render = views.gainSummary.render(testModel, -100, taxYearModel, "home-link", 150 , 11000,
+          true, fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+        f shouldBe render
+      }
     }
 
     "acquired outside current tax years" should {

--- a/test/views/calculation/whatNext/SaUserViewSpec.scala
+++ b/test/views/calculation/whatNext/SaUserViewSpec.scala
@@ -142,5 +142,14 @@ class SaUserViewSpec extends UnitSpec with WithFakeApplication with FakeRequestH
         doc.body.select("span.error-notification").size shouldBe 1
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = saUser.f(SaUserForm.saUserForm)(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = saUser.render(SaUserForm.saUserForm, fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 }

--- a/test/views/calculation/whatNext/WhatNextNonSaGainViewSpec.scala
+++ b/test/views/calculation/whatNext/WhatNextNonSaGainViewSpec.scala
@@ -95,5 +95,14 @@ class WhatNextNonSaGainViewSpec extends UnitSpec with WithFakeApplication with F
         doc.select("#exit-survey-link").attr("href") shouldBe  messages.exitSurveyLink
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.whatNextNonSaGain.f("iFormUrl")(fakeRequestWithSession, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.whatNextNonSaGain.render("iFormUrl", fakeRequestWithSession, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 }

--- a/test/views/calculation/whatNext/WhatNextNonSaLossViewSpec.scala
+++ b/test/views/calculation/whatNext/WhatNextNonSaLossViewSpec.scala
@@ -97,5 +97,14 @@ class WhatNextNonSaLossViewSpec extends UnitSpec with WithFakeApplication with F
         govUk.attr("href") shouldBe "http://www.gov.uk"
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.whatNextNonSaLoss.f("iFormUrl")(fakeRequestWithSession, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.whatNextNonSaLoss.render("iFormUrl", fakeRequestWithSession, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 }

--- a/test/views/calculation/whatNext/WhatNextSAFourTimesAEAViewSpec.scala
+++ b/test/views/calculation/whatNext/WhatNextSAFourTimesAEAViewSpec.scala
@@ -68,6 +68,15 @@ class WhatNextSAFourTimesAEAViewSpec extends UnitSpec with WithFakeApplication w
         finishButton.attr("href") shouldBe "http://www.gov.uk"
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.whatNextSAFourTimesAEA.f("back-link")(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.whatNextSAFourTimesAEA.render("back-link", fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 }
 

--- a/test/views/calculation/whatNext/WhatNextSAGainViewSpec.scala
+++ b/test/views/calculation/whatNext/WhatNextSAGainViewSpec.scala
@@ -100,5 +100,14 @@ class WhatNextSAGainViewSpec extends UnitSpec with WithFakeApplication with Fake
         doc.select("#exit-survey-link").attr("href") shouldBe  pageMessages.exitSurveyLink
       }
     }
+
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.whatNextSAGain.f("back-link", "iFormUrl", "2016 to 2017")(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      val render = views.whatNextSAGain.render("back-link", "iFormUrl", "2016 to 2017", fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+      f shouldBe render
+    }
   }
 }

--- a/test/views/calculation/whatNext/WhatNextSANoGainViewSpec.scala
+++ b/test/views/calculation/whatNext/WhatNextSANoGainViewSpec.scala
@@ -100,4 +100,13 @@ class WhatNextSANoGainViewSpec extends UnitSpec with WithFakeApplication with Fa
       }
     }
   }
+
+  "generate the same template when .render and .f are called" in {
+
+    val f = views.whatNextSANoGain.f("back-link", "iFormUrl", "2016 to 2017")(fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+    val render = views.whatNextSANoGain.render("back-link", "iFormUrl", "2016 to 2017", fakeRequest, mockMessage, fakeApplication, mockConfig)
+
+    f shouldBe render
+  }
 }

--- a/test/views/warnings/SessionTimeoutViewSpec.scala
+++ b/test/views/warnings/SessionTimeoutViewSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.warnings
+
+import config.ApplicationConfig
+import controllers.helpers.FakeRequestHelper
+import org.scalatest.mockito.MockitoSugar
+import play.api.i18n.Messages
+import play.api.mvc.MessagesControllerComponents
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import views.html.{warnings => views}
+
+class SessionTimeoutViewSpec extends UnitSpec with FakeRequestHelper with MockitoSugar with WithFakeApplication {
+
+  lazy val applicationConfig: ApplicationConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  lazy val messages: Messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+
+  val restartUrl: String = ""
+  val homeLink: String = ""
+
+  "Session timeout view" should {
+    
+    "generate the same template when .render and .f are called" in {
+
+      val f = views.sessionTimeout.f(restartUrl, homeLink)(fakeRequest, messages, fakeApplication, applicationConfig)
+
+      val render = views.sessionTimeout.render(restartUrl, homeLink, fakeRequest, messages, fakeApplication, applicationConfig)
+
+      f shouldBe render
+    }
+  }
+}


### PR DESCRIPTION
# DL-1118 - Raise Test (Statement) coverage within Cgt-calculator-resident-shares-frontend

Raised test coverage to 95.02% according to DDCTLS standard of 95%

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
