### PR TITLE
DL-2829 - Remove compilation unit test warnings on CGT-CALC-RES-SHARES-FRONTEND

### DIFF
--- a/app/controllers/DeductionsController.scala
+++ b/app/controllers/DeductionsController.scala
@@ -26,7 +26,7 @@ import forms.LossesBroughtForwardValueForm._
 import javax.inject.Inject
 import models.resident._
 import models.resident.shares.GainAnswersModel
-import play.api.Play.current
+import play.api.Application
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, Messages}
 import play.api.mvc.{Call, MessagesControllerComponents, Request, Result}
@@ -42,6 +42,7 @@ class DeductionsController @Inject()(calcConnector: CalculatorConnector,
                                      sessionCacheConnector: SessionCacheConnector,
                                      sessionCacheService: SessionCacheService,
                                      implicit val appConfig: ApplicationConfig,
+                                     implicit val application: Application,
                                      mcc: MessagesControllerComponents)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 

--- a/app/controllers/GainController.scala
+++ b/app/controllers/GainController.scala
@@ -40,7 +40,7 @@ import javax.inject.Inject
 import models.resident._
 import models.resident.shares.OwnerBeforeLegislationStartModel
 import models.resident.shares.gain.{DidYouInheritThemModel, ValueBeforeLegislationStartModel}
-import play.api.Play.current
+import play.api.Application
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, Messages}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request, Result}
@@ -58,7 +58,8 @@ class GainController @Inject()(calcConnector: CalculatorConnector,
                                sessionCacheService: SessionCacheService,
                                sessionCacheConnector: SessionCacheConnector,
                                mcc: MessagesControllerComponents)
-                               (implicit val appConfig: ApplicationConfig)
+                               (implicit val appConfig: ApplicationConfig,
+                                implicit val application: Application)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
   def navTitle(implicit request : Request[_]): String = Messages("calc.base.resident.shares.home")(mcc.messagesApi.preferred(request))

--- a/app/controllers/IncomeController.scala
+++ b/app/controllers/IncomeController.scala
@@ -28,7 +28,7 @@ import forms.PersonalAllowanceForm._
 import javax.inject.Inject
 import models.resident._
 import models.resident.income._
-import play.api.Play.current
+import play.api.Application
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, Messages}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request, Result}
@@ -41,7 +41,7 @@ import scala.concurrent.Future
 
 class IncomeController @Inject()(calcConnector: CalculatorConnector,
                                  sessionCacheConnector: SessionCacheConnector,
-                                 mcc: MessagesControllerComponents)(implicit val appConfig: ApplicationConfig)
+                                 mcc: MessagesControllerComponents)(implicit val appConfig: ApplicationConfig, implicit val application: Application)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
   def navTitle(implicit request : Request[_]): String = Messages("calc.base.resident.shares.home")(mcc.messagesApi.preferred(request))

--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -27,8 +27,8 @@ import controllers.utils.RecoverableFuture
 import it.innove.play.pdf.PdfGenerator
 import javax.inject.Inject
 import models.resident.TaxYearModel
-import play.api.Play.current
-import play.api.i18n.{I18nSupport, Messages, Lang}
+import play.api.Application
+import play.api.i18n.{I18nSupport, Lang, Messages}
 import play.api.mvc.{MessagesControllerComponents, RequestHeader}
 import services.SessionCacheService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -42,7 +42,7 @@ class ReportController @Inject()(calcConnector: CalculatorConnector,
                                  sessionCacheService: SessionCacheService,
                                  mcc: MessagesControllerComponents,
                                  pdfGenerator: PdfGenerator)
-                                (implicit val appConfig: ApplicationConfig)
+                                (implicit val appConfig: ApplicationConfig, implicit val application: Application)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
 

--- a/app/controllers/ReviewAnswersController.scala
+++ b/app/controllers/ReviewAnswersController.scala
@@ -26,7 +26,7 @@ import controllers.predicates.ValidActiveSession
 import javax.inject.Inject
 import models.resident.shares.{DeductionGainAnswersModel, GainAnswersModel}
 import models.resident.{LossesBroughtForwardModel, TaxYearModel}
-import play.api.Play.current
+import play.api.Application
 import play.api.i18n.{I18nSupport, Lang}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request, Result}
 import services.SessionCacheService
@@ -39,7 +39,7 @@ import scala.concurrent.Future
 
 class ReviewAnswersController @Inject()(calculatorConnector: CalculatorConnector,
                                         sessionCacheService: SessionCacheService,
-                                        mcc: MessagesControllerComponents)(implicit val appConfig: ApplicationConfig)
+                                        mcc: MessagesControllerComponents)(implicit val appConfig: ApplicationConfig, implicit val application: Application)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
   def getTaxYear(disposalDate: LocalDate)(implicit hc: HeaderCarrier): Future[TaxYearModel] =

--- a/app/controllers/SaUserController.scala
+++ b/app/controllers/SaUserController.scala
@@ -25,7 +25,7 @@ import forms.SaUserForm
 import javax.inject.Inject
 import models.resident._
 import models.resident.shares.{DeductionGainAnswersModel, GainAnswersModel}
-import play.api.Play.current
+import play.api.Application
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.i18n.Messages.Implicits._
@@ -35,12 +35,13 @@ import services.SessionCacheService
 import scala.concurrent.Future
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 
 class SaUserController @Inject()(calculatorConnector: CalculatorConnector,
                                  sessionCacheService: SessionCacheService,
-                                 mcc: MessagesControllerComponents)(implicit val appConfig: ApplicationConfig)
+                                 mcc: MessagesControllerComponents)(implicit val appConfig: ApplicationConfig, implicit val application: Application)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
   val saUser: Action[AnyContent] = ValidateSession.async {

--- a/app/controllers/SummaryController.scala
+++ b/app/controllers/SummaryController.scala
@@ -27,7 +27,7 @@ import controllers.utils.RecoverableFuture
 import javax.inject.Inject
 import models.resident._
 import models.resident.shares.{DeductionGainAnswersModel, GainAnswersModel}
-import play.api.Play.current
+import play.api.Application
 import play.api.i18n.I18nSupport
 import play.api.mvc.{MessagesControllerComponents, Result}
 import services.SessionCacheService
@@ -41,7 +41,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class SummaryController @Inject()(calculatorConnector: CalculatorConnector,
                                   sessionCacheService: SessionCacheService,
-                                  mcc: MessagesControllerComponents)(implicit val appConfig: ApplicationConfig)
+                                  mcc: MessagesControllerComponents)(implicit val appConfig: ApplicationConfig, implicit val application: Application)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
   override val homeLink = controllers.routes.GainController.disposalDate().url

--- a/app/controllers/WhatNextNonSaController.scala
+++ b/app/controllers/WhatNextNonSaController.scala
@@ -19,7 +19,7 @@ package controllers
 import config.ApplicationConfig
 import controllers.predicates.ValidActiveSession
 import javax.inject.Inject
-import play.api.Play.current
+import play.api.Application
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -28,7 +28,7 @@ import views.html.calculation.{whatNext => views}
 import scala.concurrent.Future
 
 class WhatNextNonSaController @Inject()(mcc: MessagesControllerComponents)
-                                       (implicit val applicationConfig: ApplicationConfig)
+                                       (implicit val applicationConfig: ApplicationConfig, implicit val application: Application)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
   val whatNextNonSaGain: Action[AnyContent] = ValidateSession.async { implicit request =>

--- a/app/controllers/WhatNextSAController.scala
+++ b/app/controllers/WhatNextSAController.scala
@@ -25,7 +25,7 @@ import connectors.SessionCacheConnector
 import controllers.predicates.ValidActiveSession
 import javax.inject.Inject
 import models.resident.DisposalDateModel
-import play.api.Play.current
+import play.api.Application
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -36,7 +36,7 @@ import scala.concurrent.Future
 
 class WhatNextSAController @Inject()(sessionCacheConnector: SessionCacheConnector,
                                      mcc: MessagesControllerComponents)
-                                    (implicit val appConfig: ApplicationConfig)
+                                    (implicit val appConfig: ApplicationConfig, implicit val application: Application)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
   val backLink: String = controllers.routes.SaUserController.saUser().url

--- a/app/controllers/utils/TimeoutController.scala
+++ b/app/controllers/utils/TimeoutController.scala
@@ -18,14 +18,14 @@ package controllers.utils
 
 import config.ApplicationConfig
 import javax.inject.Inject
-import play.api.Play.current
+import play.api.Application
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.warnings._
 
 import scala.concurrent.Future
 
-class TimeoutController @Inject()(mcc: MessagesControllerComponents)(implicit val appConfig: ApplicationConfig)
+class TimeoutController @Inject()(mcc: MessagesControllerComponents)(implicit val appConfig: ApplicationConfig, implicit val application: Application)
   extends FrontendController(mcc) {
 
   def timeout(restartUrl: String, homeLink: String) : Action[AnyContent] = Action.async { implicit request =>

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,12 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies ++= AppDependencies(),
     retrieveManaged := true,
     pipelineStages in Assets := Seq(digest),
-    evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false)
+    evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
+    scalacOptions += "-P:silencer:pathFilters=views",
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.4.4" cross CrossVersion.full),
+      "com.github.ghik" % "silencer-lib" % "1.4.4" % Provided cross CrossVersion.full
+    ),
   )
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,9 +22,9 @@ object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.3.0",
-    "uk.gov.hmrc" %% "govuk-template" % "5.48.0-play-26",
-    "uk.gov.hmrc" %% "play-ui" % "8.7.0-play-26",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.5.0",
+    "uk.gov.hmrc" %% "govuk-template" % "5.52.0-play-26",
+    "uk.gov.hmrc" %% "play-ui" % "8.8.0-play-26",
     "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-26",
     "uk.gov.hmrc" %% "http-caching-client" % "9.0.0-play-26",
     "it.innove" % "play2-pdf" % "1.9.1" exclude("com.typesafe.play","*"),
@@ -43,7 +43,7 @@ object AppDependencies {
       override lazy val test = Seq(
         "uk.gov.hmrc" %% "hmrctest" % "3.9.0-play-26" % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3" % scope,
-        "org.mockito" % "mockito-core" % "3.2.4" % scope,
+        "org.mockito" % "mockito-core" % "3.3.1" % scope,
         "org.pegdown" % "pegdown" % "1.6.0" % scope,
         "org.jsoup" % "jsoup" % "1.12.1" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,19 +5,19 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
 
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 

--- a/test/common/DatesSpec.scala
+++ b/test/common/DatesSpec.scala
@@ -22,7 +22,7 @@ import java.time.LocalDate
 import common.Dates.TemplateImplicits.RichDate
 import common.Dates.formatter
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Lang, Messages}
 
 class DatesSpec extends UnitSpec with MockitoSugar {

--- a/test/config/CgtErrorHandlerSpec.scala
+++ b/test/config/CgtErrorHandlerSpec.scala
@@ -21,7 +21,7 @@ import play.api.Application
 import play.api.http.Writeable
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Results._
-import play.api.mvc.{Action, Request, Result, Results}
+import play.api.mvc.{Action, DefaultActionBuilder, Request, Result, Results}
 import play.api.routing.Router
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -45,18 +45,19 @@ class CgtErrorHandlerSpec extends UnitSpec with WithFakeApplication {
   }
 
   val homeLink = controllers.routes.GainController.disposalDate().url
+  lazy val actionBuilder = fakeApplication.injector.instanceOf[DefaultActionBuilder]
 
   val routerForTest: Router = {
     import play.api.routing.sird._
 
     Router.from {
-      case GET(p"/ok") => Action.async { request =>
+      case GET(p"/ok") => actionBuilder.async { request =>
         Results.Ok("OK")
       }
-      case GET(p"/application-exception") => Action.async { request =>
+      case GET(p"/application-exception") => actionBuilder.async { request =>
         throw new ApplicationException(Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)), "Test exception thrown")
       }
-      case GET(p"/other-error") => Action.async { request =>
+      case GET(p"/other-error") => actionBuilder.async { request =>
         throw new IllegalArgumentException("Other Exception Thrown")
       }
     }

--- a/test/connectors/CalculatorConnectorSpec.scala
+++ b/test/connectors/CalculatorConnectorSpec.scala
@@ -26,7 +26,7 @@ import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.mockito.stubbing.OngoingStubbing
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.Environment
 import play.api.mvc.Results._
 import uk.gov.hmrc.http.logging.SessionId

--- a/test/connectors/SessionCacheConnectorSpec.scala
+++ b/test/connectors/SessionCacheConnectorSpec.scala
@@ -19,7 +19,7 @@ package connectors
 import config.ApplicationConfig
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.http.logging.SessionId

--- a/test/constructors/SummaryConstructorSpec.scala
+++ b/test/constructors/SummaryConstructorSpec.scala
@@ -20,7 +20,7 @@ import assets.MessageLookup.{SummaryPage => messages}
 import controllers.helpers.FakeRequestHelper
 import models.resident._
 import models.resident.shares.DeductionGainAnswersModel
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.MessagesProvider
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/CgtLanguageControllerSpec.scala
+++ b/test/controllers/CgtLanguageControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
 import play.api.http.FileMimeTypes
 import play.api.i18n.{Lang, Langs, MessagesApi}

--- a/test/controllers/DeductionsControllerSpec/LossesBroughtForwardActionSpec.scala
+++ b/test/controllers/DeductionsControllerSpec/LossesBroughtForwardActionSpec.scala
@@ -28,7 +28,7 @@ import controllers.{CgtLanguageController, DeductionsController}
 import models.resident._
 import models.resident.shares.{DeductionGainAnswersModel, GainAnswersModel}
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import play.api.mvc.MessagesControllerComponents
@@ -89,7 +89,7 @@ class LossesBroughtForwardActionSpec extends UnitSpec with WithFakeApplication w
 
       )
 
-    new DeductionsController(mockCalcConnector, mockSessionCacheConnector, mockSessionCacheService, mockConfig, mockMCC)
+    new DeductionsController(mockCalcConnector, mockSessionCacheConnector, mockSessionCacheService, mockConfig, fakeApplication, mockMCC)
   }
 
   "Calling .lossesBroughtForward from the resident DeductionsController" when {

--- a/test/controllers/DeductionsControllerSpec/LossesBroughtForwardValueActionSpec.scala
+++ b/test/controllers/DeductionsControllerSpec/LossesBroughtForwardValueActionSpec.scala
@@ -29,7 +29,7 @@ import models.resident.shares._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -67,7 +67,7 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
       when(mockCalcConnector.getTaxYear(ArgumentMatchers.any())(ArgumentMatchers.any()))
         .thenReturn(Future.successful(Some(taxYearModel)))
 
-      new DeductionsController(mockCalcConnector, mockSessionCacheConnector, mockSessionCacheService, mockConfig, mockMCC)
+      new DeductionsController(mockCalcConnector, mockSessionCacheConnector, mockSessionCacheService, mockConfig, fakeApplication, mockMCC)
     }
 
     "request has a valid session with no keystore data" should {
@@ -163,7 +163,7 @@ class LossesBroughtForwardValueActionSpec extends UnitSpec with WithFakeApplicat
 
         )
 
-      new DeductionsController(mockCalcConnector,mockSessionCacheConnector,mockSessionCacheService, mockConfig, mockMCC)
+      new DeductionsController(mockCalcConnector,mockSessionCacheConnector,mockSessionCacheService, mockConfig, fakeApplication, mockMCC)
     }
 
     "given a valid form" when {

--- a/test/controllers/FeedbackSurveyControllerSpec.scala
+++ b/test/controllers/FeedbackSurveyControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 

--- a/test/controllers/GainControllerSpec/AcquisitionCostsActionSpec.scala
+++ b/test/controllers/GainControllerSpec/AcquisitionCostsActionSpec.scala
@@ -31,7 +31,7 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -49,6 +49,7 @@ class AcquisitionCostsActionSpec extends UnitSpec with WithFakeApplication with 
   val gainAnswersModel = mock[GainAnswersModel]
 
   implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  implicit val mockApplication = fakeApplication
   val mockCalcConnector = mock[CalculatorConnector]
   val mockSessionCacheConnector = mock[SessionCacheConnector]
   val mockSessionCacheService: SessionCacheService = mock[SessionCacheService]

--- a/test/controllers/GainControllerSpec/AcquisitionValueActionSpec.scala
+++ b/test/controllers/GainControllerSpec/AcquisitionValueActionSpec.scala
@@ -29,7 +29,7 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -47,6 +47,7 @@ class AcquisitionValueActionSpec extends UnitSpec with WithFakeApplication with 
   def setupTarget(getData: Option[AcquisitionValueModel]): GainController = {
 
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockCalcConnector = mock[CalculatorConnector]
     val mockSessionCacheConnector = mock[SessionCacheConnector]
     val mockSessionCacheService: SessionCacheService = mock[SessionCacheService]

--- a/test/controllers/GainControllerSpec/DisposalCostsActionSpec.scala
+++ b/test/controllers/GainControllerSpec/DisposalCostsActionSpec.scala
@@ -29,7 +29,7 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -46,6 +46,7 @@ class DisposalCostsActionSpec extends UnitSpec with WithFakeApplication with Fak
 
   def setupTarget(getData: Option[DisposalCostsModel]): GainController = {
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockCalcConnector = mock[CalculatorConnector]
     val mockSessionCacheConnector = mock[SessionCacheConnector]
     val mockSessionCacheService: SessionCacheService = mock[SessionCacheService]

--- a/test/controllers/GainControllerSpec/DisposalDateActionSpec.scala
+++ b/test/controllers/GainControllerSpec/DisposalDateActionSpec.scala
@@ -30,7 +30,7 @@ import models.resident.{DisposalDateModel, TaxYearModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -48,6 +48,7 @@ class DisposalDateActionSpec extends UnitSpec with WithFakeApplication with Fake
   val mockSessionCacheConnector = mock[SessionCacheConnector]
   val mockSessionCacheService = mock[SessionCacheService]
   implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  implicit val mockApplication = fakeApplication
   val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
   def setupTarget(getData: Option[DisposalDateModel]): GainController = {

--- a/test/controllers/GainControllerSpec/DisposalValueActionSpec.scala
+++ b/test/controllers/GainControllerSpec/DisposalValueActionSpec.scala
@@ -29,7 +29,7 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -50,6 +50,7 @@ class DisposalValueActionSpec extends UnitSpec with WithFakeApplication with Fak
     val mockSessionCacheConnector = mock[SessionCacheConnector]
     val mockSessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
     when(mockSessionCacheConnector.fetchAndGetFormData[DisposalValueModel]

--- a/test/controllers/GainControllerSpec/InheritedSharesActionSpec.scala
+++ b/test/controllers/GainControllerSpec/InheritedSharesActionSpec.scala
@@ -29,7 +29,7 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -50,6 +50,7 @@ class InheritedSharesActionSpec extends UnitSpec with WithFakeApplication with F
     val mockSessionCacheConnector = mock[SessionCacheConnector]
     val mockSessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
     when(mockSessionCacheConnector.fetchAndGetFormData[DidYouInheritThemModel]

--- a/test/controllers/GainControllerSpec/OutsideTaxYearsActionSpec.scala
+++ b/test/controllers/GainControllerSpec/OutsideTaxYearsActionSpec.scala
@@ -28,7 +28,7 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -46,6 +46,7 @@ class OutsideTaxYearsActionSpec extends UnitSpec with WithFakeApplication with F
     val mockSessionCacheConnector = mock[SessionCacheConnector]
     val mockSessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
     when(mockSessionCacheConnector.fetchAndGetFormData[DisposalDateModel](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))

--- a/test/controllers/GainControllerSpec/OwnerBeforeLegislationStartActionSpec.scala
+++ b/test/controllers/GainControllerSpec/OwnerBeforeLegislationStartActionSpec.scala
@@ -29,7 +29,7 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -50,6 +50,7 @@ class OwnerBeforeLegislationStartActionSpec extends UnitSpec with WithFakeApplic
     val mockSessionCacheConnector = mock[SessionCacheConnector]
     val mockSessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
     when(mockSessionCacheConnector.fetchAndGetFormData[OwnerBeforeLegislationStartModel]

--- a/test/controllers/GainControllerSpec/SellForLessActionSpec.scala
+++ b/test/controllers/GainControllerSpec/SellForLessActionSpec.scala
@@ -29,7 +29,7 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -50,6 +50,7 @@ class SellForLessActionSpec extends UnitSpec with WithFakeApplication with FakeR
     val mockSessionCacheConnector = mock[SessionCacheConnector]
     val mockSessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
     when(mockCalcConnector.getTaxYear(ArgumentMatchers.any())(ArgumentMatchers.any()))

--- a/test/controllers/GainControllerSpec/ValueBeforeLegislationStartActionSpec.scala
+++ b/test/controllers/GainControllerSpec/ValueBeforeLegislationStartActionSpec.scala
@@ -28,7 +28,7 @@ import models.resident.shares.gain.ValueBeforeLegislationStartModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
@@ -47,6 +47,7 @@ class ValueBeforeLegislationStartActionSpec extends UnitSpec with WithFakeApplic
   val mockSessionCacheConnector = mock[SessionCacheConnector]
   val mockSessionCacheService = mock[SessionCacheService]
   implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  implicit val mockApplication = fakeApplication
   val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
   def setupTarget(getData: Option[ValueBeforeLegislationStartModel]): GainController = {

--- a/test/controllers/GainControllerSpec/WorthWhenInheritedActionSpec.scala
+++ b/test/controllers/GainControllerSpec/WorthWhenInheritedActionSpec.scala
@@ -29,7 +29,7 @@ import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -50,6 +50,7 @@ class WorthWhenInheritedActionSpec extends UnitSpec with WithFakeApplication wit
     val mockSessionCacheConnector = mock[SessionCacheConnector]
     val mockSessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
     when(mockSessionCacheConnector.fetchAndGetFormData[WorthWhenInheritedModel]

--- a/test/controllers/GainControllerSpec/WorthWhenSoldForLessActionSpec.scala
+++ b/test/controllers/GainControllerSpec/WorthWhenSoldForLessActionSpec.scala
@@ -27,7 +27,7 @@ import config.{AppConfig, ApplicationConfig}
 import controllers.{CgtLanguageController, GainController}
 import models.resident.WorthWhenSoldForLessModel
 import org.joda.time.DateTime
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.jsoup.Jsoup
 import play.api.mvc.MessagesControllerComponents
@@ -50,6 +50,7 @@ class WorthWhenSoldForLessActionSpec extends UnitSpec with WithFakeApplication w
     val mockSessionCacheConnector = mock[SessionCacheConnector]
     val mockSessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
     when(mockSessionCacheConnector.fetchAndGetFormData[WorthWhenSoldForLessModel]

--- a/test/controllers/IncomeControllerSpec/CurrentIncomeActionSpec.scala
+++ b/test/controllers/IncomeControllerSpec/CurrentIncomeActionSpec.scala
@@ -30,7 +30,7 @@ import models.resident.income._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Lang
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
@@ -55,6 +55,7 @@ class CurrentIncomeActionSpec extends UnitSpec with WithFakeApplication with Fak
     val mockCalcConnector = mock[CalculatorConnector]
     val mockSessionCacheConnector = mock[SessionCacheConnector]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
     when(mockSessionCacheConnector.fetchAndGetFormData[CurrentIncomeModel]

--- a/test/controllers/IncomeControllerSpec/PersonalAllowanceActionSpec.scala
+++ b/test/controllers/IncomeControllerSpec/PersonalAllowanceActionSpec.scala
@@ -30,7 +30,7 @@ import models.resident.{DisposalDateModel, TaxYearModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
@@ -45,6 +45,7 @@ class PersonalAllowanceActionSpec extends UnitSpec with WithFakeApplication with
   val mockCalcConnector = mock[CalculatorConnector]
   val mockSessionCacheConnector = mock[SessionCacheConnector]
   implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  implicit val mockApplication = fakeApplication
   val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
   def setupTarget(getData: Option[PersonalAllowanceModel],

--- a/test/controllers/ReportControllerSpec/DeductionsSummaryActionSpec.scala
+++ b/test/controllers/ReportControllerSpec/DeductionsSummaryActionSpec.scala
@@ -30,7 +30,7 @@ import models.resident._
 import models.resident.shares.{DeductionGainAnswersModel, GainAnswersModel}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Lang
 import play.api.mvc.{MessagesControllerComponents, RequestHeader}
 import play.api.test.Helpers._
@@ -55,6 +55,7 @@ class DeductionsSummaryActionSpec @Inject()(pdfGenerator: PdfGenerator) extends 
     lazy val mockCalculatorConnector = mock[CalculatorConnector]
     val mockSessionCacheService: SessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     implicit val mockLang = mock[Lang]
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 

--- a/test/controllers/ReportControllerSpec/FinalSummaryActionSpec.scala
+++ b/test/controllers/ReportControllerSpec/FinalSummaryActionSpec.scala
@@ -31,7 +31,7 @@ import models.resident.shares.{DeductionGainAnswersModel, GainAnswersModel}
 import models.resident.{TaxYearModel, _}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Lang
 import play.api.mvc.{MessagesControllerComponents, RequestHeader}
 import play.api.test.Helpers._
@@ -58,6 +58,7 @@ class FinalSummaryActionSpec @Inject()(pdfGenerator: PdfGenerator)extends UnitSp
     lazy val mockCalculatorConnector = mock[CalculatorConnector]
     val mockSessionCacheService: SessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     implicit val mockLang = mock[Lang]
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 

--- a/test/controllers/ReportControllerSpec/GainSummaryActionSpec.scala
+++ b/test/controllers/ReportControllerSpec/GainSummaryActionSpec.scala
@@ -30,7 +30,7 @@ import models.resident.TaxYearModel
 import models.resident.shares.GainAnswersModel
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Lang
 import play.api.mvc.{MessagesControllerComponents, RequestHeader}
 import play.api.test.Helpers._
@@ -53,6 +53,7 @@ class GainSummaryActionSpec @Inject()(pdfGenerator: PdfGenerator) extends UnitSp
     lazy val mockCalculatorConnector = mock[CalculatorConnector]
     val mockSessionCacheService: SessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     implicit val mockLang = mock[Lang]
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 

--- a/test/controllers/ReviewAnswersControllerSpec.scala
+++ b/test/controllers/ReviewAnswersControllerSpec.scala
@@ -30,7 +30,7 @@ import models.resident.shares.{DeductionGainAnswersModel, GainAnswersModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers.redirectLocation
 import services.SessionCacheService
@@ -45,6 +45,7 @@ class ReviewAnswersControllerSpec extends UnitSpec with WithFakeApplication with
   val mockSessionCacheService = mock[SessionCacheService]
   val mockConnector = mock[CalculatorConnector]
   implicit val appConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  implicit val appApplication = fakeApplication
   val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
   lazy val materializer = mock[Materializer]

--- a/test/controllers/SaUserControllerSpec.scala
+++ b/test/controllers/SaUserControllerSpec.scala
@@ -27,7 +27,7 @@ import models.resident.{ChargeableGainResultModel, TotalGainAndTaxOwedModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -44,6 +44,7 @@ class SaUserControllerSpec extends UnitSpec with FakeRequestHelper with MockitoS
   val mockConnector = mock[CalculatorConnector]
   val mockSessionCacheService: SessionCacheService = mock[SessionCacheService]
   implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  implicit val mockApplication = fakeApplication
   val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
   def setupController(gainAnswersModel: GainAnswersModel, chargeableGain: BigDecimal, totalGain: BigDecimal,

--- a/test/controllers/SummaryActionSpec.scala
+++ b/test/controllers/SummaryActionSpec.scala
@@ -28,7 +28,7 @@ import models.resident.shares._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -60,6 +60,7 @@ class SummaryActionSpec extends UnitSpec with WithFakeApplication with FakeReque
     lazy val mockCalculatorConnector = mock[CalculatorConnector]
     val mockSessionCacheService: SessionCacheService = mock[SessionCacheService]
     implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val mockApplication = fakeApplication
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
     when(mockSessionCacheService.getShareGainAnswers(ArgumentMatchers.any()))

--- a/test/controllers/WhatNextNonSaControllerSpec.scala
+++ b/test/controllers/WhatNextNonSaControllerSpec.scala
@@ -23,7 +23,7 @@ import com.codahale.metrics.SharedMetricRegistries
 import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers.redirectLocation
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
@@ -39,6 +39,7 @@ class WhatNextNonSaControllerSpec extends UnitSpec with FakeRequestHelper with W
   def setupController(): WhatNextNonSaController = {
     SharedMetricRegistries.clear()
     implicit val mockAppConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+    implicit val application = fakeApplication
     val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
 
     new WhatNextNonSaController(mockMCC)

--- a/test/controllers/WhatNextSaControllerSpec.scala
+++ b/test/controllers/WhatNextSaControllerSpec.scala
@@ -28,7 +28,8 @@ import models.resident.DisposalDateModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Application
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
@@ -50,7 +51,7 @@ class WhatNextSaControllerSpec extends UnitSpec with FakeRequestHelper with Mock
       (ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
       .thenReturn(Future.successful(Some(disposalDate)))
 
-    new WhatNextSAController(mockSessionCacheConnector, mockMCC)(mockConfig)
+    new WhatNextSAController(mockSessionCacheConnector, mockMCC)(mockConfig, fakeApplication)
   }
 
   "Calling .whatNextSAOverFourTimesAEA" when {

--- a/test/controllers/utils/RecoverableFutureSpec.scala
+++ b/test/controllers/utils/RecoverableFutureSpec.scala
@@ -75,7 +75,7 @@ class RecoverableFutureSpec extends WordSpec with ScalaFutures with Matchers wit
       var completed = false
       recoverableFuture.onComplete {
 
-        case Success(_) => completed = true
+        _ => completed = true
       }
 
       whenReady(recoverableFuture) { _ =>

--- a/test/controllers/utils/TimeoutControllerSpec.scala
+++ b/test/controllers/utils/TimeoutControllerSpec.scala
@@ -21,7 +21,7 @@ import akka.stream.Materializer
 import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Messages, MessagesProvider}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import play.api.test.FakeRequest
@@ -32,6 +32,7 @@ class TimeoutControllerSpec extends UnitSpec with WithFakeApplication with FakeR
   implicit val config = fakeApplication.injector.instanceOf[ApplicationConfig]
   implicit val mockMessagesProvider = mock[MessagesProvider]
   val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
+  implicit val mockApplication = fakeApplication
   implicit lazy val mockMessage = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
   implicit lazy val actorSystem = ActorSystem()
   lazy val materializer = mock[Materializer]

--- a/test/services/SessionCacheServiceSpec.scala
+++ b/test/services/SessionCacheServiceSpec.scala
@@ -24,7 +24,7 @@ import models.resident.income.CurrentIncomeModel
 import models.resident.shares.{DeductionGainAnswersModel, GainAnswersModel}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Results._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.{ApplicationException, DefaultHttpClient}

--- a/test/views/ErrorTemplateViewSpec.scala
+++ b/test/views/ErrorTemplateViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import views.{html => views}

--- a/test/views/GovWrapperViewSpec.scala
+++ b/test/views/GovWrapperViewSpec.scala
@@ -18,7 +18,7 @@ package views
 
 import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.api.mvc.MessagesControllerComponents
 import play.twirl.api.Html

--- a/test/views/calculation/LanguageSelectionViewSpec.scala
+++ b/test/views/calculation/LanguageSelectionViewSpec.scala
@@ -18,7 +18,7 @@ package views.calculation
 
 import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.{Lang, Messages}
 import play.api.mvc.{Call, MessagesControllerComponents}
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/views/calculation/ResidentMainTemplateViewSpec.scala
+++ b/test/views/calculation/ResidentMainTemplateViewSpec.scala
@@ -19,7 +19,7 @@ package views.calculation
 import config.ApplicationConfig
 import views.html.{calculation => views}
 import controllers.helpers.FakeRequestHelper
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.api.mvc.MessagesControllerComponents
 import play.twirl.api.Html

--- a/test/views/calculation/checkYourAnswers/CheckYourAnswersViewSpec.scala
+++ b/test/views/calculation/checkYourAnswers/CheckYourAnswersViewSpec.scala
@@ -19,8 +19,6 @@ package views.calculation.checkYourAnswers
 import controllers.helpers.FakeRequestHelper
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import org.jsoup.Jsoup
-import play.api.Play.current
-import play.api.i18n.Messages.Implicits._
 import views.html.calculation.{checkYourAnswers => views}
 import assets.MessageLookup.Resident.Shares.{ReviewAnswers => messages}
 import assets.MessageLookup.{Resident => commonMessages}

--- a/test/views/calculation/gain/DidYouInheritThemViewSpec.scala
+++ b/test/views/calculation/gain/DidYouInheritThemViewSpec.scala
@@ -25,8 +25,6 @@ import views.html.calculation.{gain => views}
 import assets.MessageLookup.{Resident => commonMessages}
 import assets.MessageLookup.Resident.Shares.{DidYouInheritThem => messages}
 import config.ApplicationConfig
-import play.api.i18n.Messages.Implicits._
-import play.api.Play.current
 import play.api.mvc.MessagesControllerComponents
 
 class DidYouInheritThemViewSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper {

--- a/test/views/calculation/gain/ResidentSharesMainTemplateViewSpec.scala
+++ b/test/views/calculation/gain/ResidentSharesMainTemplateViewSpec.scala
@@ -18,7 +18,7 @@ package views.calculation.gain
 
 import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.api.mvc.MessagesControllerComponents
 import play.twirl.api.Html

--- a/test/views/calculation/income/PersonalAllowanceViewSpec.scala
+++ b/test/views/calculation/income/PersonalAllowanceViewSpec.scala
@@ -27,8 +27,6 @@ import models.resident.TaxYearModel
 import org.jsoup.Jsoup
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import views.html.calculation.{income => views}
-import play.api.i18n.Messages.Implicits._
-import play.api.Play.current
 import play.api.mvc.MessagesControllerComponents
 
 class PersonalAllowanceViewSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper {

--- a/test/views/warnings/SessionTimeoutViewSpec.scala
+++ b/test/views/warnings/SessionTimeoutViewSpec.scala
@@ -18,7 +18,7 @@ package views.warnings
 
 import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}


### PR DESCRIPTION
# DL-2829 - Remove compilation unit test warnings on CGT-CALC-RES-SHARES-FRONTEND

Removed most warnings from cgt-calculator-resident-shares-frontend. While trying to remove the last warning by injecting an instance of `Application` into `CgtErrorHandler`, `IllegalArgumentException: A metric named jvm.attribute.vendor already exists` exceptions were thrown.

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
