### PR TITLE
DL-4355 Switch to `https` when running on an MDTP env

### DIFF
--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -27,9 +27,9 @@ import controllers.utils.RecoverableFuture
 import it.innove.play.pdf.PdfGenerator
 import javax.inject.Inject
 import models.resident.TaxYearModel
-import play.api.Application
 import play.api.i18n.{I18nSupport, Lang, Messages}
 import play.api.mvc.{MessagesControllerComponents, RequestHeader}
+import play.api.{Application, Configuration}
 import services.SessionCacheService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -38,17 +38,18 @@ import views.html.calculation.{report => views}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class ReportController @Inject()(calcConnector: CalculatorConnector,
+class ReportController @Inject()(config: Configuration,
+                                 calcConnector: CalculatorConnector,
                                  sessionCacheService: SessionCacheService,
                                  mcc: MessagesControllerComponents,
                                  pdfGenerator: PdfGenerator)
                                 (implicit val appConfig: ApplicationConfig, implicit val application: Application)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
+  lazy val platformHost: Option[String] = config.getOptional[String]("platform.frontend.host")
 
-  def host(implicit request: RequestHeader): String = {
-    s"http://${request.host}/"
-  }
+  def host(implicit request: RequestHeader): String =
+    if (platformHost.isDefined) s"https://${request.host}" else s"http://${request.host}"
 
   def getTaxYear(disposalDate: LocalDate)(implicit hc: HeaderCarrier): Future[Option[TaxYearModel]] =
     calcConnector.getTaxYear(disposalDate.format(requestFormatter))

--- a/test/controllers/ReportControllerSpec/DeductionsSummaryActionSpec.scala
+++ b/test/controllers/ReportControllerSpec/DeductionsSummaryActionSpec.scala
@@ -78,7 +78,7 @@ class DeductionsSummaryActionSpec @Inject()(pdfGenerator: PdfGenerator) extends 
     when(mockCalculatorConnector.getSharesTotalCosts(ArgumentMatchers.any())(ArgumentMatchers.any()))
       .thenReturn(Future.successful(BigDecimal(1000)))
 
-    new ReportController(mockCalculatorConnector, mockSessionCacheService, mockMCC, pdfGenerator) {
+    new ReportController(fakeApplication.configuration, mockCalculatorConnector, mockSessionCacheService, mockMCC, pdfGenerator) {
       override def host(implicit request: RequestHeader): String = "http://localhost:9977/"
     }
   }

--- a/test/controllers/ReportControllerSpec/FinalSummaryActionSpec.scala
+++ b/test/controllers/ReportControllerSpec/FinalSummaryActionSpec.scala
@@ -88,7 +88,7 @@ class FinalSummaryActionSpec @Inject()(pdfGenerator: PdfGenerator)extends UnitSp
     when(mockCalculatorConnector.getFullAEA(ArgumentMatchers.any())(ArgumentMatchers.any()))
       .thenReturn(Future.successful(Some(BigDecimal(11100))))
 
-    new ReportController(mockCalculatorConnector, mockSessionCacheService, mockMCC, pdfGenerator) {
+    new ReportController(fakeApplication.configuration, mockCalculatorConnector, mockSessionCacheService, mockMCC, pdfGenerator) {
       override def host(implicit request: RequestHeader): String = "http://localhost:9977/"
     }
   }

--- a/test/controllers/ReportControllerSpec/GainSummaryActionSpec.scala
+++ b/test/controllers/ReportControllerSpec/GainSummaryActionSpec.scala
@@ -66,7 +66,7 @@ class GainSummaryActionSpec @Inject()(pdfGenerator: PdfGenerator) extends UnitSp
     when(mockCalculatorConnector.getSharesTotalCosts(ArgumentMatchers.any())(ArgumentMatchers.any()))
       .thenReturn(Future.successful(BigDecimal(1000)))
 
-    new ReportController(mockCalculatorConnector, mockSessionCacheService, mockMCC, pdfGenerator) {
+    new ReportController(fakeApplication.configuration, mockCalculatorConnector, mockSessionCacheService, mockMCC, pdfGenerator) {
       override def host(implicit request: RequestHeader): String = "http://localhost:9977/"
     }
   }

--- a/test/controllers/ReportControllerTestSpec.scala
+++ b/test/controllers/ReportControllerTestSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.helpers.FakeRequestHelper
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.play.test.UnitSpec
+
+class ReportControllerTestSpec extends UnitSpec with FakeRequestHelper with MockitoSugar {
+
+  def buildApp(properties: Map[String, String]): Application = {
+    new GuiceApplicationBuilder().configure(properties + ("metrics.enabled" -> "false")).build()
+  }
+
+  "host" should {
+    "return a `https` host when `platform frontend host` has been set in configuration (indicates a MDTP environment)" in {
+      implicit val application: Application = buildApp(Map("platform.frontend.host" -> "https://www.qa.tax.service.gov.uk/"))
+      val controller = application.injector.instanceOf[ReportController]
+      controller.host(fakeRequest) shouldBe "https://localhost"
+    }
+    "return a `http` host when `platform frontend host` has NOT been set in configuration (indicates localhost)" in {
+      implicit val application: Application = buildApp(Map.empty)
+      val controller = application.injector.instanceOf[ReportController]
+      controller.host(fakeRequest) shouldBe "http://localhost"
+    }
+  }
+
+}


### PR DESCRIPTION
# DL-4355 Switch to `https` when running on an MDTP env

**Bug fix**

The pdf generation requires the domain to be specified so that the pdf generation can fetch the CSS. As the platform are/have enforced HTTPS the existing code was causing the request to hang and does not produce a PDF for the user.

Uses the platform.frontend-host configuration if present, in order to determine if the host should be https or just http


## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
