### PR TITLE
DL-11436 - closed timeout redirect URL

### DIFF
--- a/app/connectors/CalculatorConnector.scala
+++ b/app/connectors/CalculatorConnector.scala
@@ -40,8 +40,6 @@ class CalculatorConnector @Inject()(http: DefaultHttpClient,
 
   val serviceUrl: String = appConfig.baseUrl
 
-  val homeLink: String = controllers.routes.GainController.disposalDate.url
-
   implicit val hc: HeaderCarrier = HeaderCarrier().withExtraHeaders("Accept" -> "application/vnd.hmrc.1.0+json")
 
   def getMinimumDate()(implicit hc: HeaderCarrier): Future[LocalDate] = {
@@ -83,7 +81,7 @@ class CalculatorConnector @Inject()(http: DefaultHttpClient,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)),
+        Redirect(controllers.utils.routes.TimeoutController.timeout),
         e.getMessage
       )
   }
@@ -99,7 +97,7 @@ class CalculatorConnector @Inject()(http: DefaultHttpClient,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)),
+        Redirect(controllers.utils.routes.TimeoutController.timeout),
         e.getMessage
       )
   }
@@ -117,7 +115,7 @@ class CalculatorConnector @Inject()(http: DefaultHttpClient,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)),
+        Redirect(controllers.utils.routes.TimeoutController.timeout),
         e.getMessage
       )
   }
@@ -127,7 +125,7 @@ class CalculatorConnector @Inject()(http: DefaultHttpClient,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)),
+        Redirect(controllers.utils.routes.TimeoutController.timeout),
         e.getMessage
       )
   }

--- a/app/controllers/DeductionsController.scala
+++ b/app/controllers/DeductionsController.scala
@@ -46,8 +46,6 @@ class DeductionsController @Inject()(calcConnector: CalculatorConnector,
                                      lossesBroughtForwardValueView: lossesBroughtForwardValue)(implicit ec: ExecutionContext)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
-  override val homeLink: String = routes.GainController.disposalDate.url
-  override val sessionTimeoutUrl: String = homeLink
   def navTitle(implicit request : Request[_]): String = Messages("calc.base.resident.shares.home")(mcc.messagesApi.preferred(request))
 
 
@@ -97,9 +95,8 @@ class DeductionsController @Inject()(calcConnector: CalculatorConnector,
       implicit val lang: Lang = messagesApi.preferred(request).lang
       sessionCacheConnector.fetchAndGetFormData[LossesBroughtForwardModel](keystoreKeys.lossesBroughtForward).map {
         case Some(data) => Ok(lossesBroughtForwardView(lossesBroughtForwardForm.fill(data), lossesBroughtForwardPostAction,
-          backLinkUrl, taxYear, homeLink, navTitle))
-        case _ => Ok(lossesBroughtForwardView(lossesBroughtForwardForm, lossesBroughtForwardPostAction, backLinkUrl, taxYear,
-          homeLink, navTitle))
+          backLinkUrl, taxYear))
+        case _ => Ok(lossesBroughtForwardView(lossesBroughtForwardForm, lossesBroughtForwardPostAction, backLinkUrl, taxYear))
       }
     }
 
@@ -108,7 +105,7 @@ class DeductionsController @Inject()(calcConnector: CalculatorConnector,
       disposalDateString <- formatDisposalDate(disposalDate.get)
       taxYear <- calcConnector.getTaxYear(disposalDateString)
       finalResult <- routeRequest(lossesBroughtForwardBackUrl, taxYear.get)
-    } yield finalResult).recoverToStart(homeLink, sessionTimeoutUrl)
+    } yield finalResult).recoverToStart()
   }
 
   val submitLossesBroughtForward: Action[AnyContent] = ValidateSession.async { implicit request =>
@@ -116,8 +113,7 @@ class DeductionsController @Inject()(calcConnector: CalculatorConnector,
     def routeRequest(backUrl: String, taxYearModel: TaxYearModel): Future[Result] = {
       implicit val lang: Lang = messagesApi.preferred(request).lang
       lossesBroughtForwardForm.bindFromRequest().fold(
-        errors => Future.successful(BadRequest(lossesBroughtForwardView(errors, lossesBroughtForwardPostAction, backUrl, taxYearModel,
-          homeLink, navTitle))),
+        errors => Future.successful(BadRequest(lossesBroughtForwardView(errors, lossesBroughtForwardPostAction, backUrl, taxYearModel))),
         success => {
           sessionCacheConnector.saveFormData[LossesBroughtForwardModel](keystoreKeys.lossesBroughtForward, success).flatMap(
             _ =>if (success.option) Future.successful(Redirect(routes.DeductionsController.lossesBroughtForwardValue))
@@ -137,7 +133,7 @@ class DeductionsController @Inject()(calcConnector: CalculatorConnector,
       disposalDateString <- formatDisposalDate(disposalDate.get)
       taxYear <- calcConnector.getTaxYear(disposalDateString)
       route <- routeRequest(lossesBroughtForwardBackUrl, taxYear.get)
-    } yield route).recoverToStart(homeLink, sessionTimeoutUrl)
+    } yield route).recoverToStart()
 
   }
 
@@ -164,9 +160,7 @@ class DeductionsController @Inject()(calcConnector: CalculatorConnector,
         formData,
         taxYear,
         navBackLink = lossesBroughtForwardValueBackLink,
-        navHomeLink = homeLink,
-        postAction = lossesBroughtForwardValuePostAction,
-        navTitle
+        postAction = lossesBroughtForwardValuePostAction
       )))
     }
     (for {
@@ -175,7 +169,7 @@ class DeductionsController @Inject()(calcConnector: CalculatorConnector,
       taxYear <- calcConnector.getTaxYear(disposalDateString)
       formData <- retrieveKeystoreData(taxYear.get)
       route <- routeRequest(taxYear.get, formData)
-    } yield route).recoverToStart(homeLink, sessionTimeoutUrl)
+    } yield route).recoverToStart()
   }
 
   val submitLossesBroughtForwardValue: Action[AnyContent] = ValidateSession.async { implicit request =>
@@ -204,9 +198,7 @@ class DeductionsController @Inject()(calcConnector: CalculatorConnector,
             errors,
             taxYear.get,
             navBackLink = lossesBroughtForwardValueBackLink,
-            navHomeLink = homeLink,
-            postAction = lossesBroughtForwardValuePostAction,
-            navTitle = navTitle))
+            postAction = lossesBroughtForwardValuePostAction))
         }
       },
       success => {

--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -72,7 +72,7 @@ class ReportController @Inject()(config: Configuration,
       taxYear <- getTaxYear(answers.disposalDate)
       grossGain <- calcConnector.calculateRttShareGrossGain(answers)
     } yield {pdfGenerator.ok(gainSummaryReportView(answers, grossGain, taxYear.get, costs), host).asScala()
-      .withHeaders("Content-Disposition" -> s"""attachment; filename="${Messages("calc.resident.summary.title")}.pdf"""")}).recoverToStart(homeLink, sessionTimeoutUrl)
+      .withHeaders("Content-Disposition" -> s"""attachment; filename="${Messages("calc.resident.summary.title")}.pdf"""")}).recoverToStart()
   }
 
   //#####Deductions summary actions#####\\
@@ -89,7 +89,7 @@ class ReportController @Inject()(config: Configuration,
       chargeableGain <- calcConnector.calculateRttShareChargeableGain(answers, deductionAnswers, maxAEA.get)
     } yield
       {pdfGenerator.ok(deductionsSummaryReportView(answers, deductionAnswers, chargeableGain.get, taxYear.get, costs), host).asScala()
-      .withHeaders("Content-Disposition" -> s"""attachment; filename="${Messages("calc.resident.summary.title")}.pdf"""")}).recoverToStart(homeLink, sessionTimeoutUrl)
+      .withHeaders("Content-Disposition" -> s"""attachment; filename="${Messages("calc.resident.summary.title")}.pdf"""")}).recoverToStart()
 
   }
 
@@ -120,6 +120,6 @@ class ReportController @Inject()(config: Configuration,
         chargeableGain.get.deductions
       ),
         host).asScala().withHeaders("Content-Disposition" -> s"""attachment; filename="${Messages("calc.resident.summary.title")}.pdf"""")
-    }).recoverToStart(homeLink, sessionTimeoutUrl)
+    }).recoverToStart()
   }
 }

--- a/app/controllers/SummaryController.scala
+++ b/app/controllers/SummaryController.scala
@@ -45,9 +45,6 @@ class SummaryController @Inject()(calculatorConnector: CalculatorConnector,
                                  (implicit ec: ExecutionContext)
   extends FrontendController(mcc) with ValidActiveSession with I18nSupport {
 
-  override val homeLink = controllers.routes.GainController.disposalDate.url
-  override val sessionTimeoutUrl = homeLink
-
   val summary = ValidateSession.async { implicit request =>
 
 
@@ -100,11 +97,11 @@ class SummaryController @Inject()(calculatorConnector: CalculatorConnector,
       if (chargeableGain.isDefined && chargeableGain.get.chargeableGain > 0 &&
         incomeAnswers.personalAllowanceModel.isDefined && incomeAnswers.currentIncomeModel.isDefined) Future.successful(
         Ok(finalSummaryView(totalGainAnswers, deductionGainAnswers,
-          totalGainAndTax.get, routes.ReviewAnswersController.reviewFinalAnswers.url, taxYear.get, homeLink, totalCosts, chargeableGain.get.deductions, showUserResearchPanel = false)))
+          totalGainAndTax.get, routes.ReviewAnswersController.reviewFinalAnswers.url, taxYear.get, totalCosts, chargeableGain.get.deductions, showUserResearchPanel = false)))
 
       else if (grossGain > 0) Future.successful(Ok(deductionsSummaryView(totalGainAnswers, deductionGainAnswers,
-        chargeableGain.get, backUrl, taxYear.get, homeLink, totalCosts, showUserResearchPanel)))
-      else Future.successful(Ok(gainSummaryView(totalGainAnswers, grossGain, taxYear.get, homeLink, totalCosts, maxAea, showUserResearchPanel)))
+        chargeableGain.get, backUrl, taxYear.get, totalCosts, showUserResearchPanel)))
+      else Future.successful(Ok(gainSummaryView(totalGainAnswers, grossGain, taxYear.get, totalCosts, maxAea, showUserResearchPanel)))
     }
 
     val showUserResearchPanel = setURPanelFlag
@@ -124,7 +121,7 @@ class SummaryController @Inject()(calculatorConnector: CalculatorConnector,
       currentTaxYear = Dates.getCurrentTaxYear
       routeRequest <- routeRequest(answers, grossGain, deductionAnswers, chargeableGain, incomeAnswers, totalGain,
                                    backLink, taxYear, currentTaxYear, totalCosts, maxAEA.get, showUserResearchPanel = showUserResearchPanel)
-    } yield routeRequest).recoverToStart(homeLink, homeLink)
+    } yield routeRequest).recoverToStart()
 
   }
 

--- a/app/controllers/predicates/ValidActiveSession.scala
+++ b/app/controllers/predicates/ValidActiveSession.scala
@@ -17,17 +17,13 @@
 package controllers.predicates
 
 import play.api.mvc._
+import uk.gov.hmrc.http.SessionKeys
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
-
 import scala.concurrent.Future
-import uk.gov.hmrc.http.SessionKeys
 
 trait ValidActiveSession  {
   self: FrontendController =>
-
-  val homeLink: String = controllers.routes.GainController.disposalDate.url
-  val sessionTimeoutUrl: String = homeLink
 
   private type AsyncRequest = Request[AnyContent] => Future[Result]
 
@@ -36,7 +32,7 @@ trait ValidActiveSession  {
     def async(action: AsyncRequest): Action[AnyContent] = {
       Action.async { implicit request =>
         if (request.session.get(SessionKeys.sessionId).isEmpty) {
-          Future.successful(Redirect(controllers.utils.routes.TimeoutController.timeout(sessionTimeoutUrl, homeLink)))
+          Future.successful(Redirect(controllers.utils.routes.TimeoutController.timeout))
         } else {
           action(request)
         }

--- a/app/controllers/utils/TimeoutController.scala
+++ b/app/controllers/utils/TimeoutController.scala
@@ -27,7 +27,7 @@ class TimeoutController @Inject()(mcc: MessagesControllerComponents,
                                   sessionTimeoutView: sessionTimeout)
   extends FrontendController(mcc) {
 
-  def timeout(restartUrl: String, homeLink: String) : Action[AnyContent] = Action.async { implicit request =>
-    Future.successful(Ok(sessionTimeoutView(restartUrl, homeLink)))
+  def timeout(): Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(sessionTimeoutView()))
   }
 }

--- a/app/controllers/utils/package.scala
+++ b/app/controllers/utils/package.scala
@@ -34,12 +34,12 @@ package object utils {
     override def ready(atMost: Duration)(implicit permit: CanAwait): RecoverableFuture.this.type = ready(atMost)
     override def result(atMost: Duration)(implicit permit: CanAwait): Result = future.result(atMost)
 
-    def recoverToStart(homeLink:String, sessionTimeoutUrl: String)(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
+    def recoverToStart()(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
       future.recover {
         case e: NoSuchElementException =>
           logger.warn(s"${request.uri} resulted in None.get, user redirected to start")
           throw ApplicationException(
-            Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, sessionTimeoutUrl)),
+            Redirect(controllers.utils.routes.TimeoutController.timeout),
             e.getMessage
           )
       }

--- a/app/services/SessionCacheService.scala
+++ b/app/services/SessionCacheService.scala
@@ -34,8 +34,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class SessionCacheService @Inject()(sessionCacheConnector: SessionCacheConnector) {
 
-  val homeLink = controllers.routes.GainController.disposalDate.url
-
   def getShareGainAnswers(implicit hc: HeaderCarrier): Future[GainAnswersModel] = {
 
     val disposalDate = sessionCacheConnector.fetchAndGetFormData[DisposalDateModel](ResidentShareKeys.disposalDate)
@@ -99,7 +97,7 @@ class SessionCacheService @Inject()(sessionCacheConnector: SessionCacheConnector
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)),
+        Redirect(controllers.utils.routes.TimeoutController.timeout),
         e.getMessage
       )
   }
@@ -119,7 +117,7 @@ class SessionCacheService @Inject()(sessionCacheConnector: SessionCacheConnector
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)),
+        Redirect(controllers.utils.routes.TimeoutController.timeout),
         e.getMessage
       )
   }
@@ -137,7 +135,7 @@ class SessionCacheService @Inject()(sessionCacheConnector: SessionCacheConnector
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)),
+        Redirect(controllers.utils.routes.TimeoutController.timeout),
         e.getMessage
       )
   }

--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -52,7 +52,7 @@
 @head = {
     @if(timeoutEnabled) {
         @hmrcTimeoutDialogHelper(
-            signOutUrl = controllers.utils.routes.TimeoutController.timeout(controllers.routes.GainController.disposalDate.url, controllers.routes.GainController.disposalDate.url).url
+            signOutUrl = controllers.utils.routes.TimeoutController.timeout.url
         )
     }
     <link rel="stylesheet" type="text/css" href ='@routes.Assets.versioned("stylesheets/cgt-calculator-resident-shares.css")'>

--- a/app/views/calculation/deductions/lossesBroughtForward.scala.html
+++ b/app/views/calculation/deductions/lossesBroughtForward.scala.html
@@ -28,7 +28,7 @@
 
 )
 
-@(lossesBroughtForwardForm : Form[LossesBroughtForwardModel], postAction: Call, backLinkUrl : String, taxYear: TaxYearModel, navHomeLink: String, navTitle: String)(implicit request: Request[_], messages: Messages, lang: Lang)
+@(lossesBroughtForwardForm : Form[LossesBroughtForwardModel], postAction: Call, backLinkUrl : String, taxYear: TaxYearModel)(implicit request: Request[_], messages: Messages, lang: Lang)
 
 @hiddenHelpText = {
     <div id="helpInfo">

--- a/app/views/calculation/deductions/lossesBroughtForwardValue.scala.html
+++ b/app/views/calculation/deductions/lossesBroughtForwardValue.scala.html
@@ -25,7 +25,7 @@
     submitButton: playHelpers.submitButton
 )
 
-@(lossesBroughtForwardValueForm: Form[LossesBroughtForwardValueModel], taxYear: TaxYearModel, navBackLink: String, navHomeLink: String, postAction: Call, navTitle: String)(implicit request: Request[_], messages: Messages, lang: Lang)
+@(lossesBroughtForwardValueForm: Form[LossesBroughtForwardValueModel], taxYear: TaxYearModel, navBackLink: String, postAction: Call)(implicit request: Request[_], messages: Messages, lang: Lang)
 
 @title = @{
     if (lossesBroughtForwardValueForm.errors.nonEmpty) Messages("site.title.error",  Messages("calc.resident.lossesBroughtForwardValue.title", TaxYearModel.convertWithWelsh(taxYear.taxYearSupplied))) else Messages("calc.resident.lossesBroughtForwardValue.title", TaxYearModel.convertWithWelsh(taxYear.taxYearSupplied))

--- a/app/views/calculation/gain/acquisitionCosts.scala.html
+++ b/app/views/calculation/gain/acquisitionCosts.scala.html
@@ -25,7 +25,7 @@
     submitButton: playHelpers.submitButton
 )
 
-@(acquisitionCostsForm: Form[AcquisitionCostsModel], backHref: Some[String], homeHref: String)(implicit request: Request[_], messages: Messages)
+@(acquisitionCostsForm: Form[AcquisitionCostsModel], backHref: Some[String])(implicit request: Request[_], messages: Messages)
 
 @title = @{
     if (acquisitionCostsForm.errors.nonEmpty) Messages("site.title.error",  Messages("calc.resident.shares.acquisitionCosts.question")) else Messages("calc.resident.shares.acquisitionCosts.question")

--- a/app/views/calculation/gain/acquisitionValue.scala.html
+++ b/app/views/calculation/gain/acquisitionValue.scala.html
@@ -25,7 +25,7 @@
     submitButton: playHelpers.submitButton
 )
 
-@(acquisitionValueForm: Form[AcquisitionValueModel], navHomeLink: String)(implicit request: Request[_], messages: Messages)
+@(acquisitionValueForm: Form[AcquisitionValueModel])(implicit request: Request[_], messages: Messages)
 
 @title = @{
     if(acquisitionValueForm.errors.nonEmpty) {

--- a/app/views/calculation/gain/disposalCosts.scala.html
+++ b/app/views/calculation/gain/disposalCosts.scala.html
@@ -25,7 +25,7 @@
     formInputMoney: playHelpers.formInputMoney
 )
 
-@(disposalCostsForm: Form[DisposalCostsModel], navHomeLink: String)(implicit request: Request[_], messages: Messages)
+@(disposalCostsForm: Form[DisposalCostsModel])(implicit request: Request[_], messages: Messages)
 
 @title = @{
     if(disposalCostsForm.errors.nonEmpty) Messages("site.title.error", Messages("calc.resident.shares.disposalCosts.question"))

--- a/app/views/calculation/gain/disposalDate.scala.html
+++ b/app/views/calculation/gain/disposalDate.scala.html
@@ -26,7 +26,7 @@
     submitButton: playHelpers.submitButton
 )
 
-@(disposalDateForm: Form[DisposalDateModel], navHomeLink: String)(implicit request: Request[_], messages: Messages)
+@(disposalDateForm: Form[DisposalDateModel])(implicit request: Request[_], messages: Messages)
 
 @title = @{
     if (disposalDateForm.errors.nonEmpty) Messages("site.title.error",  Messages("calc.resident.shares.disposalDate.question")) else Messages("calc.resident.shares.disposalDate.question")

--- a/app/views/calculation/gain/disposalValue.scala.html
+++ b/app/views/calculation/gain/disposalValue.scala.html
@@ -25,7 +25,7 @@
     submitButton: playHelpers.submitButton
 )
 
-@(disposalValueForm : Form[DisposalValueModel], navHomeLink: String)(implicit request: Request[_], messages: Messages)
+@(disposalValueForm : Form[DisposalValueModel])(implicit request: Request[_], messages: Messages)
 
 @title = @{
     if (disposalValueForm.errors.nonEmpty) Messages("site.title.error",  Messages("calc.resident.shares.disposalValue.question")) else Messages("calc.resident.shares.disposalValue.question")

--- a/app/views/calculation/gain/ownerBeforeLegislationStart.scala.html
+++ b/app/views/calculation/gain/ownerBeforeLegislationStart.scala.html
@@ -26,7 +26,7 @@
     submitButton: playHelpers.submitButton
 )
 
-@(ownerBeforeLegislationStart: Form[OwnerBeforeLegislationStartModel], navHomeLink: String, navBackLink: Option[String])(implicit request: Request[_], messages: Messages)
+@(ownerBeforeLegislationStart: Form[OwnerBeforeLegislationStartModel], navBackLink: Option[String])(implicit request: Request[_], messages: Messages)
 
 @title = @{
     if (ownerBeforeLegislationStart.errors.nonEmpty) Messages("site.title.error",  Messages("calc.resident.shares.ownerBeforeLegislationStart.title")) else Messages("calc.resident.shares.ownerBeforeLegislationStart.title")

--- a/app/views/calculation/gain/sellForLess.scala.html
+++ b/app/views/calculation/gain/sellForLess.scala.html
@@ -25,7 +25,7 @@
     submitButton: playHelpers.submitButton
 )
 
-@(sellForLessForm: Form[SellForLessModel], homeHref: String, backLink: String)(implicit request: Request[_], messages: Messages)
+@(sellForLessForm: Form[SellForLessModel], backLink: String)(implicit request: Request[_], messages: Messages)
 
 @title = @{
     if (sellForLessForm.errors.nonEmpty) Messages("site.title.error",  Messages("calc.resident.shares.sellForLess.question")) else Messages("calc.resident.shares.sellForLess.question")

--- a/app/views/calculation/gain/worthWhenSoldForLess.scala.html
+++ b/app/views/calculation/gain/worthWhenSoldForLess.scala.html
@@ -25,7 +25,7 @@
     submitButton: playHelpers.submitButton
 )
 
-@(worthWhenSoldForLessForm : Form[WorthWhenSoldForLessModel], navHomeLink: String)(implicit request: Request[_], messages: Messages)
+@(worthWhenSoldForLessForm : Form[WorthWhenSoldForLessModel])(implicit request: Request[_], messages: Messages)
 
 @title = @{
     if (worthWhenSoldForLessForm.errors.nonEmpty) Messages("site.title.error",  Messages("calc.resident.shares.worthWhenSoldForLess.question")) else Messages("calc.resident.shares.worthWhenSoldForLess.question")

--- a/app/views/calculation/income/personalAllowance.scala.html
+++ b/app/views/calculation/income/personalAllowance.scala.html
@@ -27,7 +27,7 @@
     submitButton: playHelpers.submitButton
 )
 
-@(personalAllowanceForm: Form[PersonalAllowanceModel], taxYear: TaxYearModel, standardPA: BigDecimal, homeLink: String, postAction: Call, backLink: Option[String], journey: String, navTitle: String, currentTaxYear: String)(implicit request: Request[_], messages: Messages, lang: Lang)
+@(personalAllowanceForm: Form[PersonalAllowanceModel], taxYear: TaxYearModel, standardPA: BigDecimal, postAction: Call, backLink: Option[String], journey: String, currentTaxYear: String)(implicit request: Request[_], messages: Messages, lang: Lang)
 
 @defining(taxYear.taxYearSupplied == currentTaxYear) { taxYearValid =>
     @defining(

--- a/app/views/calculation/outsideTaxYear.scala.html
+++ b/app/views/calculation/outsideTaxYear.scala.html
@@ -20,7 +20,7 @@
     layout: Layout
 )
 
-@(taxYear: TaxYearModel, isAfterApril15: Boolean, isProperty: Boolean, navBackLink: String, navHomeLink: String, continueUrl: String, navTitle: String)(implicit request: Request[_], messages: Messages)
+@(taxYear: TaxYearModel, isAfterApril15: Boolean, isProperty: Boolean, navBackLink: String, continueUrl: String)(implicit request: Request[_], messages: Messages)
 
 @layout(
     pageTitle = Messages("calc.resident.outsideTaxYears.title"),

--- a/app/views/calculation/summary/deductionsSummary.scala.html
+++ b/app/views/calculation/summary/deductionsSummary.scala.html
@@ -29,7 +29,7 @@
     deductionsSummaryPartial: playHelpers.deductionsSummaryPartial
 )
 
-@(gainAnswers: GainAnswersModel, deductionAnswers: DeductionGainAnswersModel, result: ChargeableGainResultModel, backUrl: String, taxYear: TaxYearModel, navHomeLink: String, totalCosts: BigDecimal, showUserResearchPanel: Boolean)(implicit request: Request[_], messages: Messages, lang: Lang)
+@(gainAnswers: GainAnswersModel, deductionAnswers: DeductionGainAnswersModel, result: ChargeableGainResultModel, backUrl: String, taxYear: TaxYearModel, totalCosts: BigDecimal, showUserResearchPanel: Boolean)(implicit request: Request[_], messages: Messages, lang: Lang)
 
 @broughtForwardLossesHelpText() = {
     <span>

--- a/app/views/calculation/summary/finalSummary.scala.html
+++ b/app/views/calculation/summary/finalSummary.scala.html
@@ -37,7 +37,6 @@
     result: TotalGainAndTaxOwedModel,
     backUrl: String,
     taxYear: TaxYearModel,
-    navHomeLink: String,
     totalCosts: BigDecimal,
     totalDeductions: BigDecimal,
     showUserResearchPanel: Boolean)(implicit request: Request[_], messages: Messages, lang: Lang)

--- a/app/views/calculation/summary/gainSummary.scala.html
+++ b/app/views/calculation/summary/gainSummary.scala.html
@@ -23,7 +23,7 @@
     layout: Layout
 )
 
-@(answers: GainAnswersModel, gain: BigDecimal, taxYear: TaxYearModel, navHomeLink: String, totalCosts: BigDecimal, maxAea: BigDecimal, showUserResearchPanel: Boolean)(implicit request: Request[_], messages: Messages, lang: Lang)
+@(answers: GainAnswersModel, gain: BigDecimal, taxYear: TaxYearModel, totalCosts: BigDecimal, maxAea: BigDecimal, showUserResearchPanel: Boolean)(implicit request: Request[_], messages: Messages, lang: Lang)
 
 @layout(
     pageTitle = Messages("calc.resident.summary.title"),

--- a/app/views/warnings/sessionTimeout.scala.html
+++ b/app/views/warnings/sessionTimeout.scala.html
@@ -18,15 +18,16 @@
  layout: Layout
 )
 
-@(restartUrl: String, homeLink: String)(implicit request: Request[_], messages: Messages)
+@()(implicit request: Request[_], messages: Messages)
 
 @layout(
- pageTitle = Messages("session.timeout.message")
+ pageTitle = Messages("session.timeout.message"),
+ timeoutEnabled = false
 ) {
 
     <h1 class="govuk-heading-xl">@Messages("session.timeout.message")</h1>
 
-    <a id="startAgain" class="govuk-button" role="button" href="@restartUrl" data-journey-click="nav:calc:restart">@Messages("calc.summary.startAgain")</a>
+    <a id="startAgain" class="govuk-button" role="button" href="@controllers.routes.GainController.disposalDate.url" data-journey-click="nav:calc:restart">@Messages("calc.summary.startAgain")</a>
 
    <br/>
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,7 +6,7 @@
 GET         /assets/*file           @controllers.Assets.versioned(path="/public", file: Asset)
 
 #Session Timeout route
-GET         /session-timeout        @controllers.utils.TimeoutController.timeout(restartUrl: String, homeLink: String)
+GET         /session-timeout        @controllers.utils.TimeoutController.timeout
 
 #Language Controller
 GET         /language/:lang         @controllers.CgtLanguageController.switchToLanguage(lang: String)

--- a/test/config/CgtErrorHandlerSpec.scala
+++ b/test/config/CgtErrorHandlerSpec.scala
@@ -42,7 +42,6 @@ class CgtErrorHandlerSpec extends CommonPlaySpec with WithCommonFakeApplication 
     }
   }
 
-  val homeLink = controllers.routes.GainController.disposalDate.url
   lazy val actionBuilder = fakeApplication.injector.instanceOf[DefaultActionBuilder]
 
   val routerForTest: Router = {
@@ -53,7 +52,7 @@ class CgtErrorHandlerSpec extends CommonPlaySpec with WithCommonFakeApplication 
         Results.Ok("OK")
       }
       case GET(p"/application-exception") => actionBuilder.async { request =>
-        throw new ApplicationException(Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)), "Test exception thrown")
+        throw new ApplicationException(Redirect(controllers.utils.routes.TimeoutController.timeout), "Test exception thrown")
       }
       case GET(p"/other-error") => actionBuilder.async { request =>
         throw new IllegalArgumentException("Other Exception Thrown")
@@ -73,7 +72,7 @@ class CgtErrorHandlerSpec extends CommonPlaySpec with WithCommonFakeApplication 
     val request = FakeRequest("GET", "/application-exception")
     val response = routeWithError(app, request).get
     status(response) should equal(SEE_OTHER)
-    redirectLocation(response) shouldBe Some(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink).url)
+    redirectLocation(response) shouldBe Some(controllers.utils.routes.TimeoutController.timeout.url)
   }
 
   "Application throws other exception and logs error" in {

--- a/test/connectors/CalculatorConnectorSpec.scala
+++ b/test/connectors/CalculatorConnectorSpec.scala
@@ -38,16 +38,14 @@ import scala.concurrent.{ExecutionContext, Future}
 class CalculatorConnectorSpec extends CommonPlaySpec with WithCommonFakeApplication with MockitoSugar {
 
   val mockHttp = mock[DefaultHttpClient]
-  val mockSessionCacheConnector = mock[SessionCacheConnector]
   val sessionId = UUID.randomUUID.toString
-  val homeLink = controllers.routes.GainController.disposalDate.url
   val mockConfig = mock[ApplicationConfig]
 
   object TargetCalculatorConnector extends CalculatorConnector(mockHttp, mockConfig) {
     override val serviceUrl = "dummy"
   }
 
-  implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(sessionId.toString)))
+  implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(sessionId)))
 
   "Calling .getMinimumDate" should {
     def mockDate(result: Future[DateTime]): OngoingStubbing[Future[DateTime]] =
@@ -178,7 +176,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with WithCommonFakeApplicat
       mockCalculateRttShareGrossGain(Future.failed(new NoSuchElementException("error message")))
       val result = TargetCalculatorConnector.calculateRttShareGrossGain(gainAnswersMostPossibles)
       the[ApplicationException] thrownBy await(result) shouldBe ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)), "error message")
+        Redirect(controllers.utils.routes.TimeoutController.timeout), "error message")
     }
   }
 
@@ -212,7 +210,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with WithCommonFakeApplicat
       mockCalculateRttShareChargeableGain(Future.failed(new NoSuchElementException("error message")))
       val result = TargetCalculatorConnector.calculateRttShareChargeableGain(gainAnswersMostPossibles, deductionAnswersMostPossibles, 10000)
       the[ApplicationException] thrownBy await(result) shouldBe ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)), "error message")
+        Redirect(controllers.utils.routes.TimeoutController.timeout), "error message")
     }
   }
 
@@ -246,7 +244,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with WithCommonFakeApplicat
       mockCalculateRttShareTotalGainAndTax(Future.failed(new NoSuchElementException("error message")))
       val result = TargetCalculatorConnector.calculateRttShareTotalGainAndTax(gainAnswersMostPossibles, deductionAnswersMostPossibles, 10000, incomeAnswers)
       the[ApplicationException] thrownBy await(result) shouldBe ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)), "error message")
+        Redirect(controllers.utils.routes.TimeoutController.timeout), "error message")
     }
   }
 
@@ -271,7 +269,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with WithCommonFakeApplicat
       mockGetSharesTotalCosts(Future.failed(new NoSuchElementException("error message")))
       val result = TargetCalculatorConnector.getSharesTotalCosts(gainAnswersMostPossibles)
       the[ApplicationException] thrownBy await(result) shouldBe ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)), "error message")
+        Redirect(controllers.utils.routes.TimeoutController.timeout), "error message")
     }
   }
 }

--- a/test/controllers/utils/RecoverableFutureSpec.scala
+++ b/test/controllers/utils/RecoverableFutureSpec.scala
@@ -35,11 +35,9 @@ class RecoverableFutureSpec extends AnyWordSpec with ScalaFutures with Matchers 
     "convert a `NoSuchElementException` into an `ApplicationException`" in {
 
       implicit val request: Request[AnyContent] = FakeRequest()
-      val homeLink = controllers.routes.GainController.disposalDate.url
-      val sessionTimeoutUrl = homeLink
 
-      val future: Future[Result] = Future.failed(new NoSuchElementException("test message")).recoverToStart(homeLink, sessionTimeoutUrl)
-      val url = controllers.utils.routes.TimeoutController.timeout(homeLink, sessionTimeoutUrl).url
+      val future: Future[Result] = Future.failed(new NoSuchElementException("test message")).recoverToStart()
+      val url = controllers.utils.routes.TimeoutController.timeout.url
 
       whenReady(future.failed) {
         case ApplicationException(result, message) =>
@@ -53,11 +51,9 @@ class RecoverableFutureSpec extends AnyWordSpec with ScalaFutures with Matchers 
     "not convert any other exception into an `ApplicationException`" in {
 
       implicit val request: Request[AnyContent] = FakeRequest()
-      val homeLink = controllers.routes.GainController.disposalDate.url
-      val sessionTimeoutUrl = homeLink
       val ex = new IllegalArgumentException("test message")
 
-      val future: Future[Result] = Future.failed(ex).recoverToStart(homeLink, sessionTimeoutUrl)
+      val future: Future[Result] = Future.failed(ex).recoverToStart()
 
       whenReady(future.failed) {
         _ shouldBe ex

--- a/test/controllers/utils/TimeoutControllerSpec.scala
+++ b/test/controllers/utils/TimeoutControllerSpec.scala
@@ -47,19 +47,20 @@ class TimeoutControllerSpec extends CommonPlaySpec with WithCommonFakeApplicatio
   }
 
   val controller = new TimeoutController(mockMCC, sessionTimeoutView)
+  val homeLink = controllers.routes.GainController.disposalDate.url
 
   "TimeoutController.timeout" should {
 
     "when called with no session" should {
 
-      object timeoutTestDataItem extends fakeRequestTo("", controller.timeout("test", "test2"))
+      object timeoutTestDataItem extends fakeRequestTo("", controller.timeout())
 
       "return a 200" in {
         status(timeoutTestDataItem.result) shouldBe 200
       }
 
       s"have the home link too test2" in {
-        timeoutTestDataItem.jsoupDoc.select("body > header > div > div > div.govuk-header__content > a").attr("href") shouldEqual "/calculate-your-capital-gains/resident/shares/disposal-date"
+        timeoutTestDataItem.jsoupDoc.select("body > header > div > div > div.govuk-header__content > a").attr("href") shouldEqual homeLink
       }
 
       "have the title" in {
@@ -71,7 +72,7 @@ class TimeoutControllerSpec extends CommonPlaySpec with WithCommonFakeApplicatio
       }
 
       "have a restart link to href of 'test'" in {
-        timeoutTestDataItem.jsoupDoc.getElementById("startAgain").attr("href") shouldEqual "test"
+        timeoutTestDataItem.jsoupDoc.getElementById("startAgain").attr("href") shouldEqual homeLink
       }
     }
   }

--- a/test/services/SessionCacheServiceSpec.scala
+++ b/test/services/SessionCacheServiceSpec.scala
@@ -34,8 +34,6 @@ import scala.concurrent.Future
 class SessionCacheServiceSpec extends CommonPlaySpec with MockitoSugar {
 
   val mockSessionCacheConnector = mock[SessionCacheConnector]
-  val homeLink = controllers.routes.GainController.disposalDate.url
-  val mockSessionCacheService = mock[SessionCacheService]
 
   object TestSessionCacheService extends SessionCacheService(mockSessionCacheConnector) {
   }
@@ -133,7 +131,7 @@ class SessionCacheServiceSpec extends CommonPlaySpec with MockitoSugar {
       lazy val result = TestSessionCacheService.getShareGainAnswers(hc)
 
       the[ApplicationException] thrownBy await(result) shouldBe ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)), "error message")
+        Redirect(controllers.utils.routes.TimeoutController.timeout), "error message")
     }
   }
 
@@ -155,7 +153,7 @@ class SessionCacheServiceSpec extends CommonPlaySpec with MockitoSugar {
       lazy val result = TestSessionCacheService.getShareDeductionAnswers(hc)
 
       the[ApplicationException] thrownBy await(result) shouldBe ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)), "error message")
+        Redirect(controllers.utils.routes.TimeoutController.timeout), "error message")
     }
   }
 
@@ -177,7 +175,7 @@ class SessionCacheServiceSpec extends CommonPlaySpec with MockitoSugar {
       lazy val result = TestSessionCacheService.getShareIncomeAnswers(hc)
 
       the[ApplicationException] thrownBy await(result) shouldBe ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout(homeLink, homeLink)), "error message")
+        Redirect(controllers.utils.routes.TimeoutController.timeout), "error message")
     }
   }
 }

--- a/test/views/calculation/OutsideTaxYearsViewSpec.scala
+++ b/test/views/calculation/OutsideTaxYearsViewSpec.scala
@@ -35,8 +35,7 @@ class OutsideTaxYearsViewSpec extends CommonPlaySpec with WithCommonFakeApplicat
 
     "using a disposal date before 2015/16 with properties" should {
       lazy val taxYear = TaxYearModel("2014/15", false, "2015/16")
-      lazy val view = outsideTaxYearView(taxYear, false, true, "back-link", "home-link", "continue-link",
-        "navTitle")(fakeRequestWithSession, mockMessage)
+      lazy val view = outsideTaxYearView(taxYear, false, true, "back-link", "continue-link")(fakeRequestWithSession, mockMessage)
       lazy val doc = Jsoup.parse(view.body)
 
       "have charset UTF-8" in {
@@ -81,11 +80,10 @@ class OutsideTaxYearsViewSpec extends CommonPlaySpec with WithCommonFakeApplicat
 
       "generate the same template when .render and .f are called" in {
 
-        val f = outsideTaxYearView.f(taxYear, false, true, "back-link", "home-link", "continue-link",
-          "navTitle")(fakeRequestWithSession, mockMessage)
+        val f = outsideTaxYearView.f(taxYear, false, true, "back-link", "continue-link")(fakeRequestWithSession, mockMessage)
 
-        val render = outsideTaxYearView.render(taxYear, false, true, "back-link", "home-link", "continue-link",
-          "navTitle", fakeRequestWithSession, mockMessage)
+        val render = outsideTaxYearView.render(taxYear, false, true, "back-link", "continue-link",
+          fakeRequestWithSession, mockMessage)
 
         f shouldBe render
       }
@@ -93,8 +91,7 @@ class OutsideTaxYearsViewSpec extends CommonPlaySpec with WithCommonFakeApplicat
 
     "using a disposal date after 2016/17" should {
       lazy val taxYear = TaxYearModel("2017/18", false, "2016/17")
-      lazy val view = outsideTaxYearView(taxYear, true, true, "back-link", "home-link", "continue-link",
-        "navTitle")(fakeRequestWithSession, mockMessage)
+      lazy val view = outsideTaxYearView(taxYear, true, true, "back-link", "continue-link")(fakeRequestWithSession, mockMessage)
       lazy val doc = Jsoup.parse(view.body)
 
       "have charset UTF-8" in {
@@ -144,7 +141,7 @@ class OutsideTaxYearsViewSpec extends CommonPlaySpec with WithCommonFakeApplicat
 
     "using a disposal date before 2015/16 with shares" should {
       lazy val taxYear = TaxYearModel("2014/15", false, "2015/16")
-      lazy val view = outsideTaxYearView(taxYear, false, false, "back-link", "home-link", "continue-link", "navTitle")(fakeRequestWithSession, mockMessage)
+      lazy val view = outsideTaxYearView(taxYear, false, false, "back-link", "continue-link")(fakeRequestWithSession, mockMessage)
       lazy val doc = Jsoup.parse(view.body)
 
       s"have a message of ${messages.sharesTooEarly}" in {

--- a/test/views/calculation/deductions/LossesBroughtForwardValueViewSpec.scala
+++ b/test/views/calculation/deductions/LossesBroughtForwardValueViewSpec.scala
@@ -44,7 +44,7 @@ class LossesBroughtForwardValueViewSpec extends CommonPlaySpec with WithCommonFa
 
       lazy val taxYear = TaxYearModel("2015/16", true, "2015/16")
       lazy val view = lossesBroughtForwardValueView(lossesBroughtForwardValueForm, taxYear, "back-link",
-        "home-link", controllers.routes.DeductionsController.submitLossesBroughtForwardValue, "navTitle")(fakeRequest, mockMessage, fakeLang)
+        controllers.routes.DeductionsController.submitLossesBroughtForwardValue)(fakeRequest, mockMessage, fakeLang)
       lazy val doc = Jsoup.parse(view.body)
 
       "have a charset of UTF-8" in {
@@ -151,11 +151,11 @@ class LossesBroughtForwardValueViewSpec extends CommonPlaySpec with WithCommonFa
       "generate the same template when .render and .f are called" in {
 
         val f = lossesBroughtForwardValueView.f(lossesBroughtForwardValueForm, taxYear, "back-link",
-          "home-link", controllers.routes.DeductionsController.submitLossesBroughtForwardValue, "navTitle")(fakeRequest,
+          controllers.routes.DeductionsController.submitLossesBroughtForwardValue)(fakeRequest,
           mockMessage, fakeLang)
 
         val render = lossesBroughtForwardValueView.render(lossesBroughtForwardValueForm, taxYear, "back-link",
-          "home-link", controllers.routes.DeductionsController.submitLossesBroughtForwardValue, "navTitle",
+          controllers.routes.DeductionsController.submitLossesBroughtForwardValue,
           fakeRequest, mockMessage, fakeLang)
 
         f shouldBe render
@@ -166,7 +166,7 @@ class LossesBroughtForwardValueViewSpec extends CommonPlaySpec with WithCommonFa
 
       lazy val taxYear = TaxYearModel("2014/15", false, "2015/16")
       lazy val view = lossesBroughtForwardValueView(lossesBroughtForwardValueForm, taxYear, "back-link",
-        "home-link", controllers.routes.DeductionsController.submitLossesBroughtForwardValue, "navTitle")(fakeRequest, mockMessage, fakeLang)
+        controllers.routes.DeductionsController.submitLossesBroughtForwardValue)(fakeRequest, mockMessage, fakeLang)
       lazy val doc = Jsoup.parse(view.body)
 
       s"have a title ${messages.title("2014 to 2015")}" in {
@@ -201,7 +201,7 @@ class LossesBroughtForwardValueViewSpec extends CommonPlaySpec with WithCommonFa
     lazy val form = lossesBroughtForwardValueForm.bind(Map(("amount", "1000")))
     lazy val taxYear = TaxYearModel("2015/16", true, "2015/16")
     lazy val view = lossesBroughtForwardValueView(form, taxYear, "back-link",
-      "home-link", controllers.routes.DeductionsController.submitLossesBroughtForwardValue, "navTitle")(fakeRequest, mockMessage, fakeLang)
+      controllers.routes.DeductionsController.submitLossesBroughtForwardValue)(fakeRequest, mockMessage, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     "have the value of 1000 auto-filled in the input" in {
@@ -214,7 +214,7 @@ class LossesBroughtForwardValueViewSpec extends CommonPlaySpec with WithCommonFa
     lazy val form = lossesBroughtForwardValueForm.bind(Map(("amount", "")))
     lazy val taxYear = TaxYearModel("2015/16", true, "2015/16")
     lazy val view = lossesBroughtForwardValueView(form, taxYear, "back-link",
-      "home-link", controllers.routes.DeductionsController.submitLossesBroughtForwardValue, "navTitle")(fakeRequest, mockMessage, fakeLang)
+      controllers.routes.DeductionsController.submitLossesBroughtForwardValue)(fakeRequest, mockMessage, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     "display an error summary message for the amount" in {

--- a/test/views/calculation/deductions/LossesBroughtForwardViewSpec.scala
+++ b/test/views/calculation/deductions/LossesBroughtForwardViewSpec.scala
@@ -36,8 +36,7 @@ class LossesBroughtForwardViewSpec extends CommonPlaySpec with WithCommonFakeApp
 
   "Reliefs view" should {
 
-    lazy val view = lossesBroughtForwardView(lossesBroughtForwardForm, postAction, "", TaxYearModel("2015/16", true, "2015/16"),
-      "home-link", "navTitle")(fakeRequest, mockMessage, fakeLang)
+    lazy val view = lossesBroughtForwardView(lossesBroughtForwardForm, postAction, "", TaxYearModel("2015/16", true, "2015/16"))(fakeRequest, mockMessage, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     "have a charset of UTF-8" in {
@@ -89,11 +88,9 @@ class LossesBroughtForwardViewSpec extends CommonPlaySpec with WithCommonFakeApp
 
     "generate the same template when .render and .f are called" in {
 
-      val f = lossesBroughtForwardView.f(lossesBroughtForwardForm, postAction, "", TaxYearModel("2015/16", true, "2015/16"),
-        "home-link", "navTitle")(fakeRequest, mockMessage, fakeLang)
+      val f = lossesBroughtForwardView.f(lossesBroughtForwardForm, postAction, "", TaxYearModel("2015/16", true, "2015/16"))(fakeRequest, mockMessage, fakeLang)
 
-      val render = lossesBroughtForwardView.render(lossesBroughtForwardForm, postAction, "", TaxYearModel("2015/16", true, "2015/16"),
-        "home-link", "navTitle", fakeRequest, mockMessage, fakeLang)
+      val render = lossesBroughtForwardView.render(lossesBroughtForwardForm, postAction, "", TaxYearModel("2015/16", true, "2015/16"), fakeRequest, mockMessage, fakeLang)
 
       f shouldBe render
     }
@@ -101,8 +98,7 @@ class LossesBroughtForwardViewSpec extends CommonPlaySpec with WithCommonFakeApp
 
   "Losses Brought Forward view with pre-selected value of yes" should {
     lazy val form = lossesBroughtForwardForm.bind(Map(("option", "Yes")))
-    lazy val view = lossesBroughtForwardView(form, postAction, "", TaxYearModel("2015/16", true, "2015/16"),
-      "home", "navTitle")(fakeRequest, mockMessage, fakeLang)
+    lazy val view = lossesBroughtForwardView(form, postAction, "", TaxYearModel("2015/16", true, "2015/16"))(fakeRequest, mockMessage, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     "have the option 'Yes' auto selected" in {
@@ -112,8 +108,7 @@ class LossesBroughtForwardViewSpec extends CommonPlaySpec with WithCommonFakeApp
 
   "Losses Brought Forward view with pre-selected value of no" should {
     lazy val form = lossesBroughtForwardForm.bind(Map(("option", "No")))
-    lazy val view = lossesBroughtForwardView(form, postAction, "", TaxYearModel("2015/16", true, "2015/16"),
-      "home", "navTitle")(fakeRequest, mockMessage, fakeLang)
+    lazy val view = lossesBroughtForwardView(form, postAction, "", TaxYearModel("2015/16", true, "2015/16"))(fakeRequest, mockMessage, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     "have the option 'No' auto selected" in {
@@ -123,8 +118,7 @@ class LossesBroughtForwardViewSpec extends CommonPlaySpec with WithCommonFakeApp
 
   "Losses Brought Forward view with errors" should {
     lazy val form = lossesBroughtForwardForm.bind(Map(("option", "")))
-    lazy val view = lossesBroughtForwardView(form, postAction, "", TaxYearModel("2015/16", true, "2015/16"),
-      "home", "navTitle")(fakeRequest, mockMessage, fakeLang)
+    lazy val view = lossesBroughtForwardView(form, postAction, "", TaxYearModel("2015/16", true, "2015/16"))(fakeRequest, mockMessage, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     "display an error summary message for the page" in {

--- a/test/views/calculation/gain/AcquisitionCostsViewSpec.scala
+++ b/test/views/calculation/gain/AcquisitionCostsViewSpec.scala
@@ -33,7 +33,7 @@ class AcquisitionCostsViewSpec extends CommonPlaySpec with WithCommonFakeApplica
 
   "Acquisition Costs shares view" should {
 
-    lazy val view = acquisitionCostsView(acquisitionCostsForm, Some("back-link"), "home-link")(fakeRequest, mockMessage)
+    lazy val view = acquisitionCostsView(acquisitionCostsForm, Some("back-link"))(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "have a charset of UTF-8" in {
@@ -155,9 +155,9 @@ class AcquisitionCostsViewSpec extends CommonPlaySpec with WithCommonFakeApplica
 
     "generate the same template when .render and .f are called" in {
 
-      val render = acquisitionCostsView.render(acquisitionCostsForm, Some("back-link"), "home-link", fakeRequest, mockMessage)
+      val render = acquisitionCostsView.render(acquisitionCostsForm, Some("back-link"), fakeRequest, mockMessage)
 
-      val f = acquisitionCostsView.f(acquisitionCostsForm, Some("back-link"), "home-link")(fakeRequest, mockMessage)
+      val f = acquisitionCostsView.f(acquisitionCostsForm, Some("back-link"))(fakeRequest, mockMessage)
 
 
       f shouldBe render
@@ -169,7 +169,7 @@ class AcquisitionCostsViewSpec extends CommonPlaySpec with WithCommonFakeApplica
     "is due to mandatory field error" should {
 
       lazy val form = acquisitionCostsForm.bind(Map("amount" -> ""))
-      lazy val view = acquisitionCostsView(form,  Some("back-link"), "home-link")(fakeRequest, mockMessage)
+      lazy val view = acquisitionCostsView(form,  Some("back-link"))(fakeRequest, mockMessage)
       lazy val doc = Jsoup.parse(view.body)
 
       "display an error summary message for the amount" in {

--- a/test/views/calculation/gain/AcquisitionValueViewSpec.scala
+++ b/test/views/calculation/gain/AcquisitionValueViewSpec.scala
@@ -34,7 +34,7 @@ class AcquisitionValueViewSpec extends CommonPlaySpec with WithCommonFakeApplica
 
   "Acquisition Value view" should {
 
-    lazy val view = acquisitionValueView(acquisitionValueForm, "home-link")(fakeRequest, mockMessage)
+    lazy val view = acquisitionValueView(acquisitionValueForm)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "have charset UTF-8" in {
@@ -149,9 +149,9 @@ class AcquisitionValueViewSpec extends CommonPlaySpec with WithCommonFakeApplica
 
     "generate the same template when .render and .f are called" in {
 
-      val f = acquisitionValueView.f(acquisitionValueForm, "home-link")(fakeRequest, mockMessage)
+      val f = acquisitionValueView.f(acquisitionValueForm)(fakeRequest, mockMessage)
 
-      val render = acquisitionValueView.render(acquisitionValueForm, "home-link", fakeRequest, mockMessage)
+      val render = acquisitionValueView.render(acquisitionValueForm, fakeRequest, mockMessage)
 
       f shouldBe render
     }
@@ -159,7 +159,7 @@ class AcquisitionValueViewSpec extends CommonPlaySpec with WithCommonFakeApplica
 
   "Acquisition Value View with form with errors" should {
     lazy val form = acquisitionValueForm.bind(Map("amount" -> ""))
-    lazy val view = acquisitionValueView(form, "home-link")(fakeRequest, mockMessage)
+    lazy val view = acquisitionValueView(form)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "display an error summary message for the amount" in {

--- a/test/views/calculation/gain/DisposalCostsViewSpec.scala
+++ b/test/views/calculation/gain/DisposalCostsViewSpec.scala
@@ -33,7 +33,7 @@ class DisposalCostsViewSpec extends CommonPlaySpec with WithCommonFakeApplicatio
   ]
   "Disposal Costs view" should {
 
-    lazy val view = disposalCostsView(disposalCostsForm, "home-link")(fakeRequest, mockMessage)
+    lazy val view = disposalCostsView(disposalCostsForm)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "have charset UTF-8" in {
@@ -148,9 +148,9 @@ class DisposalCostsViewSpec extends CommonPlaySpec with WithCommonFakeApplicatio
 
     "generate the same template when .render and .f are called" in {
 
-      val f = disposalCostsView.f(disposalCostsForm, "home-link")(fakeRequest, mockMessage)
+      val f = disposalCostsView.f(disposalCostsForm)(fakeRequest, mockMessage)
 
-      val render = disposalCostsView.render(disposalCostsForm, "home-link", fakeRequest, mockMessage)
+      val render = disposalCostsView.render(disposalCostsForm, fakeRequest, mockMessage)
 
       f shouldBe render
     }
@@ -162,7 +162,7 @@ class DisposalCostsViewSpec extends CommonPlaySpec with WithCommonFakeApplicatio
     "is due to mandatory field error" should {
 
       lazy val form = disposalCostsForm.bind(Map("amount" -> ""))
-      lazy val view = disposalCostsView(form, "home-link")(fakeRequest, mockMessage)
+      lazy val view = disposalCostsView(form)(fakeRequest, mockMessage)
       lazy val doc = Jsoup.parse(view.body)
 
       "display an error summary message for the amount" in {

--- a/test/views/calculation/gain/DisposalDateViewSpec.scala
+++ b/test/views/calculation/gain/DisposalDateViewSpec.scala
@@ -35,7 +35,7 @@ class DisposalDateViewSpec extends CommonPlaySpec with WithCommonFakeApplication
   val disposalDateView = fakeApplication.injector.instanceOf[disposalDate]
   "Disposal Date view" should {
 
-    lazy val view = disposalDateView(disposalDateForm(LocalDate.parse("2015-04-06").atStartOfDay(ZoneId.of("Europe/London"))), "home-link")(fakeRequest, mockMessage)
+    lazy val view = disposalDateView(disposalDateForm(LocalDate.parse("2015-04-06").atStartOfDay(ZoneId.of("Europe/London"))))(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "have charset UTF-8" in {
@@ -77,10 +77,10 @@ class DisposalDateViewSpec extends CommonPlaySpec with WithCommonFakeApplication
     "generate the same template when .render and .f are called" in {
 
       val f = (disposalDateView.f(disposalDateForm(
-        LocalDate.parse("2015-04-06").atStartOfDay(ZoneId.of("Europe/London"))), "home-link")
+        LocalDate.parse("2015-04-06").atStartOfDay(ZoneId.of("Europe/London"))))
       (fakeRequest, mockMessage))
 
-      val render = disposalDateView.render(disposalDateForm(LocalDate.parse("2015-04-06").atStartOfDay(ZoneId.of("Europe/London"))), "home-link",
+      val render = disposalDateView.render(disposalDateForm(LocalDate.parse("2015-04-06").atStartOfDay(ZoneId.of("Europe/London"))),
         fakeRequest, mockMessage)
 
       f shouldBe render
@@ -90,7 +90,7 @@ class DisposalDateViewSpec extends CommonPlaySpec with WithCommonFakeApplication
   "Disposal Date view with a pre-filled form" should {
 
     lazy val form = disposalDateForm(LocalDate.parse("2015-04-06").atStartOfDay(ZoneId.of("Europe/London"))).fill(DisposalDateModel(10, 6, 2016))
-    lazy val view = disposalDateView(form, "home-link")(fakeRequest, mockMessage)
+    lazy val view = disposalDateView(form)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "have a value auto-filled in the day input" in {
@@ -113,7 +113,7 @@ class DisposalDateViewSpec extends CommonPlaySpec with WithCommonFakeApplication
       ("disposalDate.month", "10"),
       ("disposalDate.year", "2016")
     ))
-    lazy val view = disposalDateView(form, "home-link")(fakeRequest, mockMessage)
+    lazy val view = disposalDateView(form)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "have the error summary message 'Enter a real date'" in {
@@ -128,7 +128,7 @@ class DisposalDateViewSpec extends CommonPlaySpec with WithCommonFakeApplication
       ("disposalDate.month", "10"),
       ("disposalDate.year", "2016")
     ))
-    lazy val view = disposalDateView(form, "home-link")(fakeRequest, mockMessage)
+    lazy val view = disposalDateView(form)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     s"have the error summary message '${viewMessages.invalidDayError}'" in {
@@ -143,7 +143,7 @@ class DisposalDateViewSpec extends CommonPlaySpec with WithCommonFakeApplication
       ("disposalDate.month", "b"),
       ("disposalDate.year", "c")
     ))
-    lazy val view = disposalDateView(form, "home-link")(fakeRequest, mockMessage)
+    lazy val view = disposalDateView(form)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     s"have the error summary message '${viewMessages.invalidDayError}'" in {

--- a/test/views/calculation/gain/DisposalValueViewSpec.scala
+++ b/test/views/calculation/gain/DisposalValueViewSpec.scala
@@ -35,13 +35,13 @@ class DisposalValueViewSpec extends CommonPlaySpec with WithCommonFakeApplicatio
   case class FakePOST(value: String) {
     lazy val request = fakeRequestToPOSTWithSession(("amount", value)).withMethod("POST")
     lazy val form = disposalValueForm.bind(Map(("amount", value)))
-    lazy val view = disposalValueView(form, "home-link")(request, mockMessage)
+    lazy val view = disposalValueView(form)(request, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
   }
 
   "Disposal Value View" should {
 
-    lazy val view = disposalValueView(disposalValueForm, "home-link")(fakeRequest, mockMessage)
+    lazy val view = disposalValueView(disposalValueForm)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "have charset UTF-8" in {
@@ -86,9 +86,9 @@ class DisposalValueViewSpec extends CommonPlaySpec with WithCommonFakeApplicatio
 
     "generate the same template when .render and .f are called" in {
 
-      val f = disposalValueView.f(disposalValueForm, "home-link")(fakeRequest, mockMessage)
+      val f = disposalValueView.f(disposalValueForm)(fakeRequest, mockMessage)
 
-      val render = disposalValueView.render(disposalValueForm, "home-link", fakeRequest, mockMessage)
+      val render = disposalValueView.render(disposalValueForm, fakeRequest, mockMessage)
 
       f shouldBe render
     }
@@ -98,7 +98,7 @@ class DisposalValueViewSpec extends CommonPlaySpec with WithCommonFakeApplicatio
   "Disposal Value View with form without errors" should {
 
     lazy val form = disposalValueForm.bind(Map("amount" -> "100"))
-    lazy val view = disposalValueView(form, "home-link")(fakeRequest, mockMessage)
+    lazy val view = disposalValueView(form)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "display the value of the form" in {
@@ -117,7 +117,7 @@ class DisposalValueViewSpec extends CommonPlaySpec with WithCommonFakeApplicatio
   "Disposal Value View with form with errors" should {
 
     lazy val form = disposalValueForm.bind(Map("amount" -> ""))
-    lazy val view = disposalValueView(form, "home-link")(fakeRequest, mockMessage)
+    lazy val view = disposalValueView(form)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "display an error summary message for the amount" in {

--- a/test/views/calculation/gain/OwnerBeforeLegislationStartViewSpec.scala
+++ b/test/views/calculation/gain/OwnerBeforeLegislationStartViewSpec.scala
@@ -35,7 +35,7 @@ class OwnerBeforeLegislationStartViewSpec extends CommonPlaySpec with WithCommon
 
   "Owned Before 1982 view with an empty form" should {
 
-    lazy val view = ownerBeforeLegislationStartView(ownerBeforeLegislationStartForm, "home-link", Some("back-link"))(fakeRequest, mockMessage)
+    lazy val view = ownerBeforeLegislationStartView(ownerBeforeLegislationStartForm, Some("back-link"))(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
     lazy val form = doc.getElementsByTag("form")
 
@@ -204,10 +204,10 @@ class OwnerBeforeLegislationStartViewSpec extends CommonPlaySpec with WithCommon
 
     "generate the same template when .render and .f are called" in {
 
-      val f = ownerBeforeLegislationStartView.f(ownerBeforeLegislationStartForm, "home-link", Some("back-link"))(fakeRequest,
+      val f = ownerBeforeLegislationStartView.f(ownerBeforeLegislationStartForm, Some("back-link"))(fakeRequest,
         mockMessage)
 
-      val render = ownerBeforeLegislationStartView.render(ownerBeforeLegislationStartForm, "home-link", Some("back-link"), fakeRequest,
+      val render = ownerBeforeLegislationStartView.render(ownerBeforeLegislationStartForm, Some("back-link"), fakeRequest,
         mockMessage)
 
       f shouldBe render
@@ -217,7 +217,7 @@ class OwnerBeforeLegislationStartViewSpec extends CommonPlaySpec with WithCommon
   "Owned Before 1982 view with form errors" should {
 
     lazy val form = ownerBeforeLegislationStartForm.bind(Map("ownerBeforeLegislationStart" -> ""))
-    lazy val view = ownerBeforeLegislationStartView(form, "home", Some("back"))(fakeRequest, mockMessage)
+    lazy val view = ownerBeforeLegislationStartView(form, Some("back"))(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "have an error summary" which {

--- a/test/views/calculation/gain/SellForLessViewSpec.scala
+++ b/test/views/calculation/gain/SellForLessViewSpec.scala
@@ -35,7 +35,7 @@ class SellForLessViewSpec extends CommonPlaySpec with WithCommonFakeApplication 
 
   "Sell for less view with an empty form" should {
 
-    lazy val view = sellForLessView(sellForLessForm, "home-link", "back-link")(fakeRequest, mockMessage)
+    lazy val view = sellForLessView(sellForLessForm, "back-link")(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
     lazy val form = doc.getElementsByTag("form")
 
@@ -186,16 +186,16 @@ class SellForLessViewSpec extends CommonPlaySpec with WithCommonFakeApplication 
 
     "generate the same template when .render and .f are called" in {
 
-      val f = sellForLessView.f(sellForLessForm, "home-link", "back-link")(fakeRequest, mockMessage)
+      val f = sellForLessView.f(sellForLessForm, "back-link")(fakeRequest, mockMessage)
 
-      val render = sellForLessView.render(sellForLessForm, "home-link", "back-link", fakeRequest, mockMessage)
+      val render = sellForLessView.render(sellForLessForm, "back-link", fakeRequest, mockMessage)
 
       f shouldBe render
     }
   }
 
   "Sell for less view with a filled form" which {
-    lazy val view = sellForLessView(sellForLessForm.fill(SellForLessModel(true)), "home-link", "back-link")(fakeRequest, mockMessage)
+    lazy val view = sellForLessView(sellForLessForm.fill(SellForLessModel(true)), "back-link")(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "for the option 'Yes'" should {
@@ -211,7 +211,7 @@ class SellForLessViewSpec extends CommonPlaySpec with WithCommonFakeApplication 
   "Sell for less view with form errors" should {
 
     lazy val form = sellForLessForm.bind(Map("sellForLess" -> ""))
-    lazy val view = sellForLessView(form, "home-link", "back-link")(fakeRequest, mockMessage)
+    lazy val view = sellForLessView(form, "back-link")(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "have an error summary" which {

--- a/test/views/calculation/gain/WorthWhenSoldForLessViewSpec.scala
+++ b/test/views/calculation/gain/WorthWhenSoldForLessViewSpec.scala
@@ -34,7 +34,7 @@ class WorthWhenSoldForLessViewSpec extends CommonPlaySpec with WithCommonFakeApp
 
   "The Shares Worth When Sold For Less View when supplied with an empty form" should {
 
-    lazy val view = worthWhenSoldForLessView(worthWhenSoldForLessForm, "home-link")(fakeRequest, mockMessage)
+    lazy val view = worthWhenSoldForLessView(worthWhenSoldForLessForm)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "have a charset of UTF-8" in {
@@ -145,9 +145,9 @@ class WorthWhenSoldForLessViewSpec extends CommonPlaySpec with WithCommonFakeApp
 
     "generate the same template when .render and .f are called" in {
 
-      val f = worthWhenSoldForLessView.f(worthWhenSoldForLessForm, "home-link")(fakeRequest, mockMessage)
+      val f = worthWhenSoldForLessView.f(worthWhenSoldForLessForm)(fakeRequest, mockMessage)
 
-      val render = worthWhenSoldForLessView.render(worthWhenSoldForLessForm, "home-link", fakeRequest, mockMessage)
+      val render = worthWhenSoldForLessView.render(worthWhenSoldForLessForm, fakeRequest, mockMessage)
 
       f shouldBe render
     }
@@ -156,7 +156,7 @@ class WorthWhenSoldForLessViewSpec extends CommonPlaySpec with WithCommonFakeApp
   "The Shares Worth When Sold For Less View when supplied with a correct form" should {
 
     lazy val form = worthWhenSoldForLessForm.bind(Map("amount" -> "100"))
-    lazy val view = worthWhenSoldForLessView(form, "home-link")(fakeRequest, mockMessage)
+    lazy val view = worthWhenSoldForLessView(form)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "display the value of the form in the input" in {
@@ -175,7 +175,7 @@ class WorthWhenSoldForLessViewSpec extends CommonPlaySpec with WithCommonFakeApp
   "The Shares Worth When Sold For Less View when supplied with an incorrect form" should {
 
     lazy val form = worthWhenSoldForLessForm.bind(Map("amount" -> "adsa"))
-    lazy val view = worthWhenSoldForLessView(form, "home-link")(fakeRequest, mockMessage)
+    lazy val view = worthWhenSoldForLessView(form)(fakeRequest, mockMessage)
     lazy val doc = Jsoup.parse(view.body)
 
     "display an error summary message for the amount" in {

--- a/test/views/calculation/income/PersonalAllowanceViewSpec.scala
+++ b/test/views/calculation/income/PersonalAllowanceViewSpec.scala
@@ -46,8 +46,8 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
     "supplied with a 2015 to 2016 tax year" should {
 
       lazy val taxYearModel = TaxYearModel("2015/16", true, "2015/16")
-      lazy val view = personalAllowanceView(personalAllowanceForm, taxYearModel, BigDecimal(10600), "home", postAction,
-        Some("back-link"), JourneyKeys.shares, "navTitle", Dates.getCurrentTaxYear)(fakeRequest, mockMessage,fakeLang)
+      lazy val view = personalAllowanceView(personalAllowanceForm, taxYearModel, BigDecimal(10600), postAction,
+        Some("back-link"), JourneyKeys.shares, Dates.getCurrentTaxYear)(fakeRequest, mockMessage,fakeLang)
       lazy val doc = Jsoup.parse(view.body)
 
       "have a charset of UTF-8" in {
@@ -164,8 +164,8 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
       "Personal Allowance view with stored values" should {
         lazy val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
         lazy val form = personalAllowanceForm.bind(Map(("amount", "1000")))
-        lazy val view = personalAllowanceView(form, taxYearModel, BigDecimal(10600), "home", postAction,
-          Some("back-link"), JourneyKeys.shares, "navTitle", "2015 to 16")(fakeRequest, mockMessage, fakeLang)
+        lazy val view = personalAllowanceView(form, taxYearModel, BigDecimal(10600), postAction,
+          Some("back-link"), JourneyKeys.shares, "2015 to 16")(fakeRequest, mockMessage, fakeLang)
         lazy val doc = Jsoup.parse(view.body)
 
         "have the value of 1000 auto-filled in the input" in {
@@ -176,11 +176,11 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
 
       "generate the same template when .render and .f are called" in {
 
-        val f = personalAllowanceView.f(personalAllowanceForm, taxYearModel, BigDecimal(10600), "home", postAction,
-          Some("back-link"), JourneyKeys.shares, "navTitle", Dates.getCurrentTaxYear)(fakeRequest, mockMessage, fakeLang)
+        val f = personalAllowanceView.f(personalAllowanceForm, taxYearModel, BigDecimal(10600), postAction,
+          Some("back-link"), JourneyKeys.shares, Dates.getCurrentTaxYear)(fakeRequest, mockMessage, fakeLang)
 
-        val render = personalAllowanceView.render(personalAllowanceForm, taxYearModel, BigDecimal(10600), "home", postAction,
-          Some("back-link"), JourneyKeys.shares, "navTitle", Dates.getCurrentTaxYear, fakeRequest, mockMessage, fakeLang)
+        val render = personalAllowanceView.render(personalAllowanceForm, taxYearModel, BigDecimal(10600), postAction,
+          Some("back-link"), JourneyKeys.shares, Dates.getCurrentTaxYear, fakeRequest, mockMessage, fakeLang)
 
         f shouldBe render
       }
@@ -190,8 +190,8 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
     "supplied with the current tax year" should {
 
       lazy val taxYearModel = TaxYearModel(Dates.getCurrentTaxYear, true, Dates.getCurrentTaxYear)
-      lazy val view = personalAllowanceView(personalAllowanceForm, taxYearModel, BigDecimal(11000), "home", postAction,
-        Some("back-link"), JourneyKeys.shares, "navTitle", Dates.getCurrentTaxYear)(fakeRequest, mockMessage, fakeLang)
+      lazy val view = personalAllowanceView(personalAllowanceForm, taxYearModel, BigDecimal(11000), postAction,
+        Some("back-link"), JourneyKeys.shares, Dates.getCurrentTaxYear)(fakeRequest, mockMessage, fakeLang)
       lazy val doc = Jsoup.parse(view.body)
       lazy val h1Tag = doc.select("H1")
 
@@ -211,8 +211,8 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
     "supplied with a tax year a year after the current tax year" should {
 
       lazy val taxYearModel = TaxYearModel(DateAsset.getYearAfterCurrentTaxYear, false, Dates.getCurrentTaxYear)
-      lazy val view = personalAllowanceView(personalAllowanceForm, taxYearModel, BigDecimal(11000), "home", postAction,
-        Some("back-link"), JourneyKeys.shares, "navTitle", Dates.getCurrentTaxYear)(fakeRequest, mockMessage, fakeLang)
+      lazy val view = personalAllowanceView(personalAllowanceForm, taxYearModel, BigDecimal(11000), postAction,
+        Some("back-link"), JourneyKeys.shares, Dates.getCurrentTaxYear)(fakeRequest, mockMessage, fakeLang)
       lazy val doc = Jsoup.parse(view.body)
       lazy val h1Tag = doc.select("H1")
 
@@ -239,8 +239,8 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
 
         lazy val taxYearModel = TaxYearModel("2015/16", true, "2015/16")
         lazy val form = personalAllowanceForm.bind(Map("amount" -> ""))
-        lazy val view = personalAllowanceView(form, taxYearModel, BigDecimal(11000), "home", postAction,
-          Some("back-link"), JourneyKeys.shares, "navTitle", Dates.getCurrentTaxYear)(fakeRequest, mockMessage, fakeLang)
+        lazy val view = personalAllowanceView(form, taxYearModel, BigDecimal(11000), postAction,
+          Some("back-link"), JourneyKeys.shares, Dates.getCurrentTaxYear)(fakeRequest, mockMessage, fakeLang)
         lazy val doc = Jsoup.parse(view.body)
 
         "display an error summary message for the amount" in {

--- a/test/views/calculation/summary/SharesDeductionsSummaryViewSpec.scala
+++ b/test/views/calculation/summary/SharesDeductionsSummaryViewSpec.scala
@@ -71,7 +71,7 @@ class SharesDeductionsSummaryViewSpec extends CommonPlaySpec with WithCommonFake
     lazy val backUrl = controllers.routes.ReviewAnswersController.reviewDeductionsAnswers.url
 
     lazy val view = deductionsSummaryView(gainAnswers, deductionAnswers, results, backUrl,
-      taxYearModel, "home-link", 100, showUserResearchPanel = true)(fakeRequestWithSession, mockMessage, fakeLang)
+      taxYearModel, 100, showUserResearchPanel = true)(fakeRequestWithSession, mockMessage, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     "have a charset of UTF-8" in {
@@ -180,10 +180,10 @@ class SharesDeductionsSummaryViewSpec extends CommonPlaySpec with WithCommonFake
     "generate the same template when .render and .f are called" in {
 
       val f = deductionsSummaryView.f(gainAnswers, deductionAnswers, results, backUrl,
-        taxYearModel, "home-link", 100, true)(fakeRequestWithSession, mockMessage, fakeLang)
+        taxYearModel, 100, true)(fakeRequestWithSession, mockMessage, fakeLang)
 
       val render = deductionsSummaryView.render(gainAnswers, deductionAnswers, results, backUrl,
-        taxYearModel, "home-link", 100, true, fakeRequestWithSession, mockMessage, fakeLang)
+        taxYearModel, 100, true, fakeRequestWithSession, mockMessage, fakeLang)
 
       f shouldBe render
     }
@@ -226,7 +226,7 @@ class SharesDeductionsSummaryViewSpec extends CommonPlaySpec with WithCommonFake
     lazy val backUrl = controllers.routes.ReviewAnswersController.reviewDeductionsAnswers.url
 
     lazy val view = deductionsSummaryView(gainAnswers, deductionAnswers, results, backUrl,
-      taxYearModel, "home-link", 100, showUserResearchPanel = false)(fakeRequestWithSession, mockMessage, fakeLang)
+      taxYearModel, 100, showUserResearchPanel = false)(fakeRequestWithSession, mockMessage, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     "not display the what to do next section" in {

--- a/test/views/calculation/summary/SharesFinalSummaryViewSpec.scala
+++ b/test/views/calculation/summary/SharesFinalSummaryViewSpec.scala
@@ -87,7 +87,6 @@ class SharesFinalSummaryViewSpec extends CommonPlaySpec with WithCommonFakeAppli
         results,
         backLinkUrl,
         taxYearModel,
-        "",
         100,
         100,
         showUserResearchPanel = true)(fakeRequestWithSession, mockMessage, fakeLang)
@@ -452,10 +451,10 @@ class SharesFinalSummaryViewSpec extends CommonPlaySpec with WithCommonFakeAppli
 
       "generate the same template when .render and .f are called" in {
 
-        val f = finalSummaryView.f(gainAnswers, deductionAnswers, results, backLinkUrl, taxYearModel, "", 100, 100,
+        val f = finalSummaryView.f(gainAnswers, deductionAnswers, results, backLinkUrl, taxYearModel, 100, 100,
           true)(fakeRequestWithSession, mockMessage, fakeLang)
 
-        val render = finalSummaryView.render(gainAnswers, deductionAnswers, results, backLinkUrl, taxYearModel, "", 100, 100,
+        val render = finalSummaryView.render(gainAnswers, deductionAnswers, results, backLinkUrl, taxYearModel, 100, 100,
           true, fakeRequestWithSession, mockMessage, fakeLang)
 
         f shouldBe render
@@ -504,7 +503,6 @@ class SharesFinalSummaryViewSpec extends CommonPlaySpec with WithCommonFakeAppli
         results,
         backLinkUrl,
         taxYearModel,
-        "",
         100,
         100,
         showUserResearchPanel = false)(fakeRequestWithSession, mockMessage, fakeLang)

--- a/test/views/calculation/summary/SharesGainSummaryViewSpec.scala
+++ b/test/views/calculation/summary/SharesGainSummaryViewSpec.scala
@@ -55,7 +55,7 @@ class SharesGainSummaryViewSpec extends CommonPlaySpec with WithCommonFakeApplic
       )
 
       lazy val taxYearModel = TaxYearModel("2016/17", true, "2016/17")
-      lazy val view = gainSummaryView(testModel, -100, taxYearModel, "home-link", 150 , 11000, showUserResearchPanel = true)(fakeRequest, mockMessage, fakeLang)
+      lazy val view = gainSummaryView(testModel, -100, taxYearModel, 150 , 11000, showUserResearchPanel = true)(fakeRequest, mockMessage, fakeLang)
       lazy val doc = Jsoup.parse(view.body)
 
       "have a charset of UTF-8" in {
@@ -383,10 +383,10 @@ class SharesGainSummaryViewSpec extends CommonPlaySpec with WithCommonFakeApplic
 
       "generate the same template when .render and .f are called" in {
 
-        val f = gainSummaryView.f(testModel, -100, taxYearModel, "home-link", 150 , 11000,
+        val f = gainSummaryView.f(testModel, -100, taxYearModel, 150 , 11000,
           true)(fakeRequest, mockMessage, fakeLang)
 
-        val render = gainSummaryView.render(testModel, -100, taxYearModel, "home-link", 150 , 11000,
+        val render = gainSummaryView.render(testModel, -100, taxYearModel, 150 , 11000,
           true, fakeRequest, mockMessage, fakeLang)
 
         f shouldBe render
@@ -409,7 +409,7 @@ class SharesGainSummaryViewSpec extends CommonPlaySpec with WithCommonFakeApplic
       )
 
       lazy val taxYearModel = TaxYearModel("2016/17", false, "2016/17")
-      lazy val view = gainSummaryView(testModel, -100, taxYearModel, "home-link", 150 , 11000, showUserResearchPanel = false)(fakeRequest, mockMessage, fakeLang)
+      lazy val view = gainSummaryView(testModel, -100, taxYearModel, 150 , 11000, showUserResearchPanel = false)(fakeRequest, mockMessage, fakeLang)
       lazy val doc = Jsoup.parse(view.body)
 
       "not display the continue button" in {

--- a/test/views/warnings/SessionTimeoutViewSpec.scala
+++ b/test/views/warnings/SessionTimeoutViewSpec.scala
@@ -31,15 +31,14 @@ class SessionTimeoutViewSpec extends CommonPlaySpec with FakeRequestHelper with 
   val sessionTimeoutView = fakeApplication.injector.instanceOf[sessionTimeout]
 
   val restartUrl: String = ""
-  val homeLink: String = ""
 
   "Session timeout view" should {
     
     "generate the same template when .render and .f are called" in {
 
-      val f = sessionTimeoutView.f(restartUrl, homeLink)(fakeRequest, messages)
+      val f = sessionTimeoutView.f()(fakeRequest, messages)
 
-      val render = sessionTimeoutView.render(restartUrl, homeLink, fakeRequest, messages)
+      val render = sessionTimeoutView.render(fakeRequest, messages)
 
       f shouldBe render
     }


### PR DESCRIPTION
# DL-11436 - closed timeout redirect URL

- removed unused parameters `homeLink` and `navTitle` from views
- set `timeoutEnabled=false` for `sessionTimeout.scala.html`

Going to `http://localhost:9704/calculate-your-capital-gains/resident/shares/session-timeout?restartUrl=%68%74%74%70%73%3a%2f%2f%77%77%77%2e%67%6f%6f%67%6c%65%2e%63%6f%6d&homeLink=/` and clicking the 'start again' button now navigates to `/calculate-your-capital-gains/resident/shares/disposal-date`

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
