### PR TITLE
DL-12067 fixed unintended BigDecimal behaviour

### DIFF
--- a/app/common/Transformers.scala
+++ b/app/common/Transformers.scala
@@ -26,7 +26,7 @@ object Transformers {
   }
 
   val bigDecimalToString: BigDecimal => String = (input) => input.scale match {
-    case 1 => input.setScale(2).toString()
+    case scale if scale < 2 && scale != 0 => input.setScale(2).toString()
     case _ => input.toString
   }
 

--- a/app/constructors/CalculateRequestConstructor.scala
+++ b/app/constructors/CalculateRequestConstructor.scala
@@ -23,10 +23,10 @@ import models.resident.IncomeAnswersModel
 object CalculateRequestConstructor {
 
   def totalGainRequestString (answers: GainAnswersModel): String = {
-    s"?disposalValue=${determineDisposalValueToUse(answers)}" +
-      s"&disposalCosts=${answers.disposalCosts}" +
-      s"&acquisitionValue=${determineAcquisitionValueToUse(answers)}" +
-      s"&acquisitionCosts=${answers.acquisitionCosts}" +
+    s"?disposalValue=${determineDisposalValueToUse(answers).toDouble}" +
+      s"&disposalCosts=${answers.disposalCosts.toDouble}" +
+      s"&acquisitionValue=${determineAcquisitionValueToUse(answers).toDouble}" +
+      s"&acquisitionCosts=${answers.acquisitionCosts.toDouble}" +
       s"&disposalDate=${answers.disposalDate.format(requestFormatter)}"
   }
 
@@ -43,13 +43,13 @@ object CalculateRequestConstructor {
 
   def chargeableGainRequestString (answers: DeductionGainAnswersModel, maxAEA: BigDecimal): String = {
       s"${if (answers.broughtForwardModel.get.option)
-        s"&broughtForwardLosses=${answers.broughtForwardValueModel.get.amount}"
+        s"&broughtForwardLosses=${answers.broughtForwardValueModel.get.amount.toDouble}"
       else ""}" +
-      s"&annualExemptAmount=$maxAEA"
+      s"&annualExemptAmount=${maxAEA.toDouble}"
   }
 
   def incomeAnswersRequestString (deductionsAnswers: DeductionGainAnswersModel, answers: IncomeAnswersModel): String = {
-      s"&previousIncome=${answers.currentIncomeModel.get.amount}" +
-      s"&personalAllowance=${answers.personalAllowanceModel.get.amount}"
+      s"&previousIncome=${answers.currentIncomeModel.get.amount.toDouble}" +
+      s"&personalAllowance=${answers.personalAllowanceModel.get.amount.toDouble}"
   }
 }

--- a/app/forms/CurrentIncomeForm.scala
+++ b/app/forms/CurrentIncomeForm.scala
@@ -39,7 +39,7 @@ class CurrentIncomeForm @Inject()(implicit val messagesApi: MessagesApi) extends
         "amount" -> text
           .verifying(messagesApi(s"calc.resident.currentIncome.$question.error.mandatoryAmount", taxYear)(lang), mandatoryCheck)
           .verifying(messagesApi(s"calc.resident.currentIncome.$question.error.invalidAmount", taxYear)(lang), bigDecimalCheck)
-          .transform[BigDecimal](stringToBigDecimal, _.toString())
+          .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)
           .verifying(maxMonetaryValueConstraint(Constants.maxNumeric))
           .verifying(messagesApi(s"calc.resident.currentIncome.$question.error.minimumAmount", taxYear)(lang), isPositive)
           .verifying(messagesApi(s"calc.resident.currentIncome.$question.error.invalidAmount", taxYear)(lang), decimalPlacesCheck)

--- a/app/forms/PersonalAllowanceForm.scala
+++ b/app/forms/PersonalAllowanceForm.scala
@@ -36,7 +36,7 @@ class PersonalAllowanceForm @Inject()(implicit val messagesApi: MessagesApi) {
       "amount" -> text
         .verifying(messagesApi("calc.resident.personalAllowance.error.mandatoryAmount", taxYear)(lang), mandatoryCheck)
         .verifying(messagesApi("calc.resident.personalAllowance.error.invalidAmount", taxYear)(lang), bigDecimalCheck)
-        .transform[BigDecimal](stringToBigDecimal, _.toString())
+        .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)
         .verifying(maxMonetaryValueConstraint(maxPA))
         .verifying(messagesApi("calc.resident.personalAllowance.error.minimumAmount", taxYear)(lang), isPositive)
         .verifying(messagesApi("calc.resident.personalAllowance.error.invalidAmount", taxYear)(lang), decimalPlacesCheckNoDecimal)

--- a/test/common/TransformersSpec.scala
+++ b/test/common/TransformersSpec.scala
@@ -42,14 +42,16 @@ class TransformersSpec extends CommonPlaySpec {
 
     "Converting a BigDecimal to a String" should {
 
-      "pad BigDecimals to 2 decimal places if they only have 1" in {
+      "pad BigDecimals to 2 decimal places if they have a non 0 scale less than 2" in {
 
         val bigDecimal = BigDecimal(1234.5)
+        val bigDecimalNegativeScale = BigDecimal("1.2345E+3")
 
         Transformers.bigDecimalToString(bigDecimal) shouldBe bigDecimal.setScale(2).toString
+        Transformers.bigDecimalToString(bigDecimalNegativeScale) shouldBe bigDecimal.setScale(2).toString()
       }
 
-      "call .toString on BigDecimals that don't have 1 decimal place" in {
+      "call .toString on BigDecimals with no decimal places or more than 1 decimal" in {
 
         val bigDecimalNoDecimalPlaces = BigDecimal(1234)
         val bigDecimalSomeDecimalPlaces = BigDecimal(1234.56789)

--- a/test/constructors/CalculateRequestConstructorSpec.scala
+++ b/test/constructors/CalculateRequestConstructorSpec.scala
@@ -42,10 +42,10 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
         acquisitionCosts = 100
       )
       val result = CalculateRequestConstructor.totalGainRequestString(answers)
-      result shouldBe s"?disposalValue=1000" +
-        s"&disposalCosts=0" +
-        s"&acquisitionValue=500" +
-        s"&acquisitionCosts=100" +
+      result shouldBe s"?disposalValue=1000.0" +
+        s"&disposalCosts=0.0" +
+        s"&acquisitionValue=500.0" +
+        s"&acquisitionCosts=100.0" +
         s"&disposalDate=2016-02-10"
     }
   }
@@ -58,7 +58,7 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
         val answers = DeductionGainAnswersModel(Some(LossesBroughtForwardModel(false)),
           None)
         val result = CalculateRequestConstructor.chargeableGainRequestString(answers, BigDecimal(11100))
-        result shouldBe "&annualExemptAmount=11100"
+        result shouldBe "&annualExemptAmount=11100.0"
       }
     }
 
@@ -68,7 +68,7 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
         val answers = DeductionGainAnswersModel(Some(LossesBroughtForwardModel(true)),
           Some(LossesBroughtForwardValueModel(BigDecimal(2000))))
         val result = CalculateRequestConstructor.chargeableGainRequestString(answers, BigDecimal(11100))
-        result shouldBe "&broughtForwardLosses=2000&annualExemptAmount=11100"
+        result shouldBe "&broughtForwardLosses=2000.0&annualExemptAmount=11100.0"
       }
     }
   }
@@ -81,7 +81,7 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
 
       "return a valid request string" in {
         val result = CalculateRequestConstructor.incomeAnswersRequestString(deductionGainAnswersModel, incomeGainAnswersModel)
-        result shouldBe "&previousIncome=1000&personalAllowance=10600"
+        result shouldBe "&previousIncome=1000.0&personalAllowance=10600.0"
       }
     }
   }


### PR DESCRIPTION
BigDecimals that are too big and ended in 0.00 were being displayed with scientific notation, this ensures the forms play back user inputs only with 2 decimals or 0, overriding the automatic sci notation. Also updated the backend calls to turn big decimals to doubles first to avoid the same issue and better conform to backend url parameter types.