### PR TITLE
Dls 9451 currency validation

### DIFF
--- a/app/common/Transformers.scala
+++ b/app/common/Transformers.scala
@@ -20,6 +20,12 @@ import scala.util.{Failure, Success, Try}
 
 object Transformers {
 
+  val stripCurrencyCharacters: String => String = (input) =>
+    input
+      .trim()
+      .replaceAll(",", "")
+      .replaceAll("£", "")
+
   val stringToBigDecimal: String => BigDecimal = (input) => Try(BigDecimal(input.trim)) match {
     case Success(value) => value
     case Failure(_) => BigDecimal(0)

--- a/app/forms/AcquisitionCostsForm.scala
+++ b/app/forms/AcquisitionCostsForm.scala
@@ -28,6 +28,7 @@ object AcquisitionCostsForm {
   lazy val acquisitionCostsForm = Form(
     mapping(
       "amount" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.shares.acquisitionCosts.error.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.shares.acquisitionCosts.error.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/AcquisitionValueForm.scala
+++ b/app/forms/AcquisitionValueForm.scala
@@ -28,6 +28,7 @@ object AcquisitionValueForm {
   lazy val acquisitionValueForm = Form(
     mapping(
       "amount" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.shares.acquisitionValue.error.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.shares.acquisitionValue.error.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/CurrentIncomeForm.scala
+++ b/app/forms/CurrentIncomeForm.scala
@@ -37,6 +37,7 @@ class CurrentIncomeForm @Inject()() extends Logging {
     Form(
       mapping(
         "amount" -> text
+          .transform(stripCurrencyCharacters, stripCurrencyCharacters)
           .verifying(messages(s"calc.resident.currentIncome.$question.error.mandatoryAmount", taxYear), mandatoryCheck)
           .verifying(messages(s"calc.resident.currentIncome.$question.error.invalidAmount", taxYear), bigDecimalCheck)
           .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/DisposalCostsForm.scala
+++ b/app/forms/DisposalCostsForm.scala
@@ -28,6 +28,7 @@ object DisposalCostsForm {
   lazy val disposalCostsForm = Form(
     mapping(
       "amount" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.shares.disposalCosts.error.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.shares.disposalCosts.error.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/DisposalValueForm.scala
+++ b/app/forms/DisposalValueForm.scala
@@ -28,6 +28,7 @@ object DisposalValueForm {
   lazy val disposalValueForm = Form(
     mapping(
       "amount" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.shares.disposalValue.error.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.shares.disposalValue.error.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/LossesBroughtForwardValueForm.scala
+++ b/app/forms/LossesBroughtForwardValueForm.scala
@@ -31,6 +31,7 @@ class LossesBroughtForwardValueForm @Inject()(implicit val messagesApi: Messages
   def apply(year: String, lang: Lang): Form[LossesBroughtForwardValueModel] = Form(
     mapping(
       "amount" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying(messagesApi("calc.resident.lossesBroughtForwardValue.error.mandatoryAmount", year)(lang), mandatoryCheck)
         .verifying(messagesApi("calc.resident.lossesBroughtForwardValue.error.invalidAmount", year)(lang), bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/PersonalAllowanceForm.scala
+++ b/app/forms/PersonalAllowanceForm.scala
@@ -34,6 +34,7 @@ class PersonalAllowanceForm @Inject()(implicit val messagesApi: MessagesApi) {
   def apply(maxPA: BigDecimal = BigDecimal(0), taxYear: String, lang: Lang): Form[PersonalAllowanceModel] = Form(
     mapping(
       "amount" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying(messagesApi("calc.resident.personalAllowance.error.mandatoryAmount", taxYear)(lang), mandatoryCheck)
         .verifying(messagesApi("calc.resident.personalAllowance.error.invalidAmount", taxYear)(lang), bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/ValueBeforeLegislationStartForm.scala
+++ b/app/forms/ValueBeforeLegislationStartForm.scala
@@ -28,6 +28,7 @@ object ValueBeforeLegislationStartForm {
   lazy val valueBeforeLegislationStartForm = Form(
     mapping(
       "amount" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.shares.valueBeforeLegislationStart.error.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.shares.valueBeforeLegislationStart.error.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/WorthWhenInheritedForm.scala
+++ b/app/forms/WorthWhenInheritedForm.scala
@@ -28,6 +28,7 @@ object WorthWhenInheritedForm {
   lazy val worthWhenInheritedForm = Form(
     mapping(
       "amount" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.shares.worthWhenInherited.error.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.shares.worthWhenInherited.error.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/WorthWhenSoldForLessForm.scala
+++ b/app/forms/WorthWhenSoldForLessForm.scala
@@ -28,6 +28,7 @@ object WorthWhenSoldForLessForm {
   lazy val worthWhenSoldForLessForm = Form(
     mapping(
       "amount" -> text
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.shares.worthWhenSoldForLess.error.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.shares.worthWhenSoldForLess.error.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.14.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.15.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 

--- a/test/common/TransformersSpec.scala
+++ b/test/common/TransformersSpec.scala
@@ -25,6 +25,27 @@ class TransformersSpec extends CommonPlaySpec {
 
   "The Transformers object" when {
 
+    "stripping currency characters" should {
+      "return a cleaned currency amount" when {
+        "the transform is applied to an amount with commas and pound signs" in {
+          val result = Transformers.stripCurrencyCharacters("£1,999")
+          result shouldBe "1999"
+        }
+        "the transform is applied to an amount with commas" in {
+          val result = Transformers.stripCurrencyCharacters("1,999")
+          result shouldBe "1999"
+        }
+        "the transform is applied to an amount with pound signs" in {
+          val result = Transformers.stripCurrencyCharacters("£1999")
+          result shouldBe "1999"
+        }
+        "the transform is applied to an amount without commas and pound signs" in {
+          val result = Transformers.stripCurrencyCharacters("1999")
+          result shouldBe "1999"
+        }
+      }
+    }
+
     "Converting a String to a BigDecimal" should {
 
       "successfully parse a valid string to a BigDecimal value" in {


### PR DESCRIPTION
# DLS-9451 forgive commas and pound signs on all currency inputs

**New feature**

This will mean users who enter or copy and paste currency amounts with commas and/or pound signs in them will not get errors because of that.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
