### PR TITLE
DLS-9986: Delivery of content changes [Accessibility ticket]

### DIFF
--- a/app/views/calculation/gain/valueBeforeLegislationStart.scala.html
+++ b/app/views/calculation/gain/valueBeforeLegislationStart.scala.html
@@ -40,7 +40,9 @@
 ) {
     @errorSummary(valueBeforeLegislationStartForm.errors)
 
-    <h1 class="govuk-heading-xl">@messages("calc.resident.shares.valueBeforeLegislationStart.question")</h1>
+    <div style="width: 79%">
+        <h1 class="govuk-heading-xl">@messages("calc.resident.shares.valueBeforeLegislationStart.question")</h1>
+    </div>
 
     <p class="govuk-body">@messages("calc.resident.shares.valueBeforeLegislationStart.information")</p>
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -68,7 +68,7 @@ calc.resident.personalAllowance.list.one = ennill mwy na £100,000
 calc.resident.personalAllowance.list.title = Yn y flwyddyn dreth {0}, £{1} oedd Lwfans Personol y DU, oni bai eich bod wedi gwneud y canlynol:
 calc.resident.personalAllowance.list.two = hawlio Lwfans Person Dall
 calc.resident.personalAllowance.list.three = hawlio Lwfans Priodasol
-calc.resident.personalAllowance.question = Yn y flwyddyn dreth {0}, faint oedd eich Lwfans Personol?
+calc.resident.personalAllowance.question = Lwfans Personol
 calc.resident.personalAllowance.error.mandatoryAmount = Nodwch beth oedd eich Lwfans Personol ar gyfer blwyddyn dreth {0}
 calc.resident.personalAllowance.error.invalidAmount = Mae''n rhaid i beth oedd eich Lwfans Personol ar gyfer blwyddyn dreth {0} fod yn y fformat cywir
 calc.resident.personalAllowance.error.minimumAmount = Mae''n rhaid i beth oedd eich Lwfans Personol ar gyfer blwyddyn dreth {0} fod yn 0 neu fwy
@@ -78,13 +78,13 @@ calc.resident.saUser.title = Ydych chi''n rhan o''r drefn Hunanasesiad ar hyn o 
 
 calc.resident.shares.acquisitionCosts.help = Mae hyn yn cynnwys costau ar gyfer ffioedd broceriaid stoc a Thollau Stamp.
 calc.resident.shares.acquisitionCosts.hintText = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi''ch cyfran chi o''r costau, fel y cytunwyd gyda''ch cydberchennog.
-calc.resident.shares.acquisitionCosts.question = Faint y gwnaethoch ei dalu o ran costau pan gawsoch y cyfranddaliadau?
+calc.resident.shares.acquisitionCosts.question = Y costau pan wnaethoch gael y cyfranddaliadau
 calc.resident.shares.acquisitionCosts.error.mandatoryAmount = Nodwch faint y gwnaethoch ei dalu o ran costau pan gawsoch y cyfranddaliadau
 calc.resident.shares.acquisitionCosts.error.invalidAmount = Mae''n rhaid i faint y gwnaethoch ei dalu o ran costau pan gawsoch y cyfranddaliadau fod yn y fformat cywir
 calc.resident.shares.acquisitionCosts.error.minimumAmount = Mae''n rhaid i faint y gwnaethoch ei dalu o ran costau pan gawsoch y cyfranddaliadau fod yn 0 neu fwy
 
 calc.resident.shares.acquisitionValue.hintText = Os oeddech yn berchen arnynt gyda rhywun arall, dylech ond nodi''ch cyfran chi o''r pryniant.
-calc.resident.shares.acquisitionValue.question = Faint y gwnaethoch ei dalu am y cyfranddaliadau?
+calc.resident.shares.acquisitionValue.question = Yr hyn y a dalwyd gennych am y cyfranddaliadau
 calc.resident.shares.acquisitionValue.error.mandatoryAmount = Nodwch faint y gwnaethoch ei dalu am y cyfranddaliadau
 calc.resident.shares.acquisitionValue.error.invalidAmount = Mae''n rhaid i faint y gwnaethoch ei dalu am y cyfranddaliadau fod yn y fformat cywir
 calc.resident.shares.acquisitionValue.error.minimumAmount = Mae''n rhaid i faint y gwnaethoch ei dalu am y cyfranddaliadau fod yn 0 neu fwy
@@ -99,7 +99,7 @@ calc.resident.shares.didYouInheritThem.question = A wnaethoch etifeddu''r cyfran
 
 calc.resident.shares.disposalCosts.helpText = Mae hyn yn cynnwys costau ar gyfer ffioedd broceriaid stoc.
 calc.resident.shares.disposalCosts.jointOwnership = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi''ch cyfran chi o''r costau, fel y cytunwyd gyda''ch cydberchennog.
-calc.resident.shares.disposalCosts.question = Faint y gwnaethoch ei dalu o ran costau wrth werthu''r cyfranddaliadau?
+calc.resident.shares.disposalCosts.question = Y costau pan wnaethoch werthu’r cyfranddaliadau
 calc.resident.shares.disposalCosts.error.mandatoryAmount = Nodwch faint y gwnaethoch ei dalu o ran costau pan wnaethoch werthu''r cyfranddaliadau
 calc.resident.shares.disposalCosts.error.invalidAmount = Mae''n rhaid i faint y gwnaethoch ei dalu o ran costau pan wnaethoch werthu''r cyfranddaliadau fod yn y fformat cywir
 calc.resident.shares.disposalCosts.error.minimumAmount = Mae''n rhaid i faint y gwnaethoch ei dalu o ran costau pan wnaethoch werthu''r cyfranddaliadau fod yn 0 neu fwy
@@ -126,7 +126,7 @@ disposalDate.error.notReal.year            = Nodwch flwyddyn go iawn ar gyfer y 
 disposalDate.error.range.min               = Mae’n rhaid i’r dyddiad y gwnaethoch werthu’r cyfranddaliadau, neu eu rhoi i ffwrdd, fod ar ôl {0}
 
 calc.resident.shares.disposalValue.jointOwnership = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi''ch cyfran chi o''r pris gwerthu.
-calc.resident.shares.disposalValue.question = Am faint y gwnaethoch werthu''r cyfranddaliadau?
+calc.resident.shares.disposalValue.question = Gwerth y cyfranddaliadau pan gawsant eu gwerthu
 calc.resident.shares.disposalValue.error.mandatoryAmount = Nodwch faint y gwnaethoch werthu''r cyfranddaliadau amdano
 calc.resident.shares.disposalValue.error.invalidAmount = Mae''n rhaid i faint y gwnaethoch werthu''r cyfranddaliadau amdano fod yn y fformat cywir
 calc.resident.shares.disposalValue.error.minimumAmount = Mae''n rhaid i faint y gwnaethoch werthu''r cyfranddaliadau amdano fod yn 0 neu fwy
@@ -142,22 +142,22 @@ calc.resident.shares.sellForLess.question = A wnaethoch werthu''r cyfranddaliada
 
 calc.resident.shares.valueBeforeLegislationStart.help = Cewch wybodaeth am y prisiad o''r gyfnewidfa stoc neu siaradwch â''ch brocer stoc neu reolwr eich cronfa.
 calc.resident.shares.valueBeforeLegislationStart.hintText = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi gwerth eich cyfran chi o''r cyfranddaliadau.
-calc.resident.shares.valueBeforeLegislationStart.information = Os cawsoch eich cyfranddaliadau cyn 31 Mawrth 1982, defnyddiwch y gwerth marchnadol ar 31 Mawrth 1982 i gyfrifo''ch Treth Enillion Cyfalaf. Ar ôl y dyddiad hwn, defnyddiwch y gost wreiddiol.
-calc.resident.shares.valueBeforeLegislationStart.question = Beth oedd gwerth y cyfranddaliadau ar 31 Mawrth 1982?
+calc.resident.shares.valueBeforeLegislationStart.information = Os cawsoch eich cyfranddaliadau cyn 31 Mawrth 1982, defnyddiwch y gwerth marchnadol ar 31 Mawrth 1982 i gyfrifo''ch Treth Enillion Cyfalaf.
+calc.resident.shares.valueBeforeLegislationStart.question = Roeddech yn berchen ar y cyfranddaliadau cyn 1 Ebrill 1982
 calc.resident.shares.valueBeforeLegislationStart.error.mandatoryAmount = Nodwch beth oedd gwerth y cyfranddaliadau ar 31 Mawrth 1982
 calc.resident.shares.valueBeforeLegislationStart.error.invalidAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau ar 31 Mawrth 1982 fod yn y fformat cywir
 calc.resident.shares.valueBeforeLegislationStart.error.minimumAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau ar 31 Mawrth 1982 fod yn 0 neu fwy
 
 calc.resident.shares.worthWhenInherited.help = Defnyddiwch wybodaeth o''r gyfnewidfa stoc neu siaradwch â''ch brocer stoc neu reolwr eich cronfa.
 calc.resident.shares.worthWhenInherited.hintText = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi''r gwerth marchnadol ar gyfer eich cyfran chi o''r cyfranddaliadau.
-calc.resident.shares.worthWhenInherited.question = Beth oedd gwerth y cyfranddaliadau pan wnaethoch eu hetifeddu?
+calc.resident.shares.worthWhenInherited.question = Gwerth y cyfranddaliadau pan gawsant eu hetifeddu
 calc.resident.shares.worthWhenInherited.error.mandatoryAmount = Nodwch beth oedd gwerth y cyfranddaliadau pan wnaethoch eu hetifeddu
 calc.resident.shares.worthWhenInherited.error.invalidAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau pan wnaethoch eu hetifeddu fod yn y fformat cywir
 calc.resident.shares.worthWhenInherited.error.minimumAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau pan wnaethoch eu hetifeddu fod yn 0 neu fwy
 
 calc.resident.shares.worthWhenSoldForLess.informationText = Cewch wybodaeth o''r gyfnewidfa stoc neu siaradwch â''ch brocer stoc neu reolwr eich cronfa.
 calc.resident.shares.worthWhenSoldForLess.jointOwnershipText = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi gwerth eich cyfran chi o''r cyfranddaliadau.
-calc.resident.shares.worthWhenSoldForLess.question = Beth oedd gwerth y cyfranddaliadau pan wnaethoch eu gwerthu?
+calc.resident.shares.worthWhenSoldForLess.question = Y gwerth marchnadol pan gawsant eu gwerthu
 calc.resident.shares.worthWhenSoldForLess.error.mandatoryAmount = Nodwch beth oedd gwerth y cyfranddaliadau pan wnaethoch eu gwerthu
 calc.resident.shares.worthWhenSoldForLess.error.invalidAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau pan wnaethoch eu gwerthu fod yn y fformat cywir
 calc.resident.shares.worthWhenSoldForLess.error.minimumAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau pan wnaethoch eu gwerthu fod yn 0 neu fwy

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -96,7 +96,7 @@ calc.resident.currentIncome.questionCurrentYear.error.invalidAmount = How much y
 calc.resident.currentIncome.questionCurrentYear.error.minimumAmount = How much you expect your income to be in this year must be £0 or more
 
 ## Personal Allowance messages
-calc.resident.personalAllowance.question = In the {0} tax year, what was your Personal Allowance?
+calc.resident.personalAllowance.question = Personal Allowance
 calc.resident.personalAllowance.list.title = In the tax year {0} the UK Personal Allowance was £{1} unless you:
 calc.resident.personalAllowance.help = This is the amount of your income that you do not pay tax on.
 calc.resident.personalAllowance.list.one = earned more than £100,000
@@ -136,7 +136,7 @@ disposalDate.error.notReal.year            = Enter a real year for when you sold
 disposalDate.error.range.min               = The date you sold or gave away the shares must be after {0}
 
 ## Disposal Value messages
-calc.resident.shares.disposalValue.question = How much did you sell the shares for?
+calc.resident.shares.disposalValue.question = Shares value when sold
 calc.resident.shares.disposalValue.jointOwnership = If you owned the shares with someone else, only enter your portion of the sale value.
 calc.resident.shares.disposalValue.error.mandatoryAmount = Enter how much you sold the shares for
 calc.resident.shares.disposalValue.error.invalidAmount = How much you sold the shares for must be in the correct format
@@ -147,7 +147,7 @@ calc.resident.shares.sellForLess.question = Did you sell the shares for less tha
 calc.resident.shares.sellForLess.noSelectError = Tell us if you sold the shares for less than they were worth to help the buyer.
 
 ## Worth When Sold For Less messages
-calc.resident.shares.worthWhenSoldForLess.question = What were the shares worth when you sold them?
+calc.resident.shares.worthWhenSoldForLess.question = Market value when sold
 calc.resident.shares.worthWhenSoldForLess.informationText = Get information from the stock exchange or talk to your stockbroker or fund manager.
 calc.resident.shares.worthWhenSoldForLess.jointOwnershipText = If you owned the shares with someone else, only enter the value of your portion of the shares.
 calc.resident.shares.worthWhenSoldForLess.error.mandatoryAmount = Enter how much the shares were worth when you sold them
@@ -155,7 +155,7 @@ calc.resident.shares.worthWhenSoldForLess.error.invalidAmount = How much the sha
 calc.resident.shares.worthWhenSoldForLess.error.minimumAmount = How much the shares were worth when you sold them must be 0 or more
 
 ## Disposal Costs messages
-calc.resident.shares.disposalCosts.question = How much did you pay in costs when you sold the shares?
+calc.resident.shares.disposalCosts.question = Costs when you sold the shares
 calc.resident.shares.disposalCosts.helpText = This includes costs for stockbroker fees.
 calc.resident.shares.disposalCosts.jointOwnership = If you owned the shares with someone else, only enter your portion of the costs as agreed with your co-owner.
 calc.resident.shares.disposalCosts.error.mandatoryAmount = Enter how much you paid in costs when you sold the shares
@@ -163,8 +163,8 @@ calc.resident.shares.disposalCosts.error.invalidAmount = How much you paid in co
 calc.resident.shares.disposalCosts.error.minimumAmount = How much you paid in costs when you sold the shares must be 0 or more
 
 ## Worth On messages
-calc.resident.shares.valueBeforeLegislationStart.question = What were the shares worth on 31 March 1982?
-calc.resident.shares.valueBeforeLegislationStart.information = If you had your shares before 31 March 1982, use the market value on 31 March 1982 to work out your Capital Gains Tax. After this date, use the original cost.
+calc.resident.shares.valueBeforeLegislationStart.question = You owned the shares before 1 April 1982
+calc.resident.shares.valueBeforeLegislationStart.information = Because you owned the shares before 1 April 1982, you need to use the market value on 31 March 1982 to work out your Capital Gains Tax.
 calc.resident.shares.valueBeforeLegislationStart.help = Get valuation information from the stock exchange or talk to your stockbroker or fund manager.
 calc.resident.shares.valueBeforeLegislationStart.hintText = If you owned the shares with someone else, only enter the value of your portion of the shares.
 calc.resident.shares.valueBeforeLegislationStart.error.mandatoryAmount = Enter what the shares were worth on 31 March 1982
@@ -177,7 +177,7 @@ calc.resident.shares.ownerBeforeLegislationStart.help = If you had your shares b
 calc.resident.shares.ownerBeforeLegislationStart.noSelectError = Tell us if you owned the shares before 1 April 1982
 
 ## Worth When Inherited
-calc.resident.shares.worthWhenInherited.question = What were the shares worth when you inherited them?
+calc.resident.shares.worthWhenInherited.question = Shares value when inherited
 calc.resident.shares.worthWhenInherited.help = Use information from the stock exchange or talk to your stockbroker or fund manager.
 calc.resident.shares.worthWhenInherited.hintText = If you owned the shares with someone else, only enter the market value for your portion of the shares.
 calc.resident.shares.worthWhenInherited.error.mandatoryAmount = Enter what the shares were worth when you inherited them
@@ -189,14 +189,14 @@ calc.resident.shares.didYouInheritThem.errorSelect = Tell us if you inherited th
 calc.resident.shares.didYouInheritThem.question = Did you inherit the shares?
 
 ## Acquisition Value messages
-calc.resident.shares.acquisitionValue.question = How much did you pay for the shares?
+calc.resident.shares.acquisitionValue.question = What you paid for the shares
 calc.resident.shares.acquisitionValue.hintText = If you owned them with someone else, only enter your share of the purchase.
 calc.resident.shares.acquisitionValue.error.mandatoryAmount = Enter how much you paid for the shares
 calc.resident.shares.acquisitionValue.error.invalidAmount = How much you paid for the shares must be in the correct format
 calc.resident.shares.acquisitionValue.error.minimumAmount = How much you paid for the shares must be 0 or more
 
 ## Acquisition Costs messages
-calc.resident.shares.acquisitionCosts.question = How much did you pay in costs when you got the shares?
+calc.resident.shares.acquisitionCosts.question = Costs when you got the shares
 calc.resident.shares.acquisitionCosts.help = This includes costs for stockbroker fees and Stamp Duty.
 calc.resident.shares.acquisitionCosts.hintText = If you owned the shares with someone else, only enter your portion of the costs as agreed with your co-owner.
 calc.resident.shares.acquisitionCosts.error.mandatoryAmount = Enter how much you paid in costs when you got the shares

--- a/test/assets/MessageLookup.scala
+++ b/test/assets/MessageLookup.scala
@@ -400,16 +400,16 @@ object MessageLookup {
       object SharesSummaryMessages {
 
         val disposalDateQuestion = "When did you sell or give away the shares?"
-        val disposalValueQuestion = "How much did you sell the shares for?"
-        val disposalCostsQuestion = "How much did you pay in costs when you sold the shares?"
-        val acquisitionValueQuestion = "How much did you pay for the shares?"
-        val acquisitionCostsQuestion = "How much did you pay in costs when you got the shares?"
+        val disposalValueQuestion = "Shares value when sold"
+        val disposalCostsQuestion = "Costs when you sold the shares"
+        val acquisitionValueQuestion = "What you paid for the shares"
+        val acquisitionCostsQuestion = "Costs when you got the shares"
 
       }
 
       object ValueBeforeLegislationStart {
-        val title = "What were the shares worth on 31 March 1982? - Calculate your Capital Gains Tax - GOV.UK"
-        val question = "What were the shares worth on 31 March 1982?"
+        val title = "You owned the shares before 1 April 1982 - Calculate your Capital Gains Tax - GOV.UK"
+        val question = "You owned the shares before 1 April 1982"
         val information = "If you had your shares before 31 March 1982, use the market value on 31 March 1982 to work " +
           "out your Capital Gains Tax. After this date, use the original cost."
         val helpText = "Get valuation information from the stock exchange or talk to your stockbroker or fund manager."
@@ -418,8 +418,8 @@ object MessageLookup {
       }
 
       object DisposalValue {
-        val title = "How much did you sell the shares for? - Calculate your Capital Gains Tax - GOV.UK"
-        val question = "How much did you sell the shares for?"
+        val title = "Shares value when sold - Calculate your Capital Gains Tax - GOV.UK"
+        val question = "Shares value when sold"
         val jointOwnership = "If you owned the shares with someone else, only enter your portion of the sale value."
         val nonValidDate = "Enter a real date Enter a date that is after 6 4 2015"
       }
@@ -445,16 +445,16 @@ object MessageLookup {
 
       //############ Worth When Inherited messages.en #################//
       object WorthWhenInherited {
-        val title = "What were the shares worth when you inherited them? - Calculate your Capital Gains Tax - GOV.UK"
-        val question = "What were the shares worth when you inherited them?"
+        val title = "Shares value when inherited - Calculate your Capital Gains Tax - GOV.UK"
+        val question = "Shares value when inherited"
         val helpText = "Use information from the stock exchange or talk to your stockbroker or fund manager."
         val hintText = "If you owned the shares with someone else, only enter the market value for your portion of the shares."
       }
 
       //############ Worth When Sold For Less messages.en #################//
       object WorthWhenSoldForLess {
-        val title = "What were the shares worth when you sold them? - Calculate your Capital Gains Tax - GOV.UK"
-        val question = "What were the shares worth when you sold them?"
+        val title = "Market value when sold - Calculate your Capital Gains Tax - GOV.UK"
+        val question = "Market value when sold"
         val informationText = "Get information from the stock exchange or talk to your stockbroker or fund manager."
         val jointOwnershipText = "If you owned the shares with someone else, only enter the value of your portion of the shares."
       }
@@ -673,8 +673,8 @@ object MessageLookup {
 
   //Personal Allowance messages.en
   object PersonalAllowance {
-    def question(input: String): String = s"In the $input tax year, what was your Personal Allowance?"
-    def title(input: String): String = s"In the $input tax year, what was your Personal Allowance? - Calculate your Capital Gains Tax - GOV.UK"
+    def question(input: String): String = "Personal Allowance"
+    def title(input: String): String = "Personal Allowance - Calculate your Capital Gains Tax - GOV.UK"
     val link = "Income tax rates and Personal Allowances"
     val linkText = "Find out more about"
     val help = "This is the amount of your income that you do not pay tax on."
@@ -708,22 +708,22 @@ object MessageLookup {
   }
 
   object SharesAcquisitionCosts {
-    val title = "How much did you pay in costs when you got the shares? - Calculate your Capital Gains Tax - GOV.UK"
-    val question = "How much did you pay in costs when you got the shares?"
+    val title = "Costs when you got the shares - Calculate your Capital Gains Tax - GOV.UK"
+    val question = "Costs when you got the shares"
     val helpText = "This includes costs for stockbroker fees and Stamp Duty."
     val hintText = "If you owned the shares with someone else, only enter your portion of the costs as agreed with your co-owner."
   }
 
   object SharesDisposalCosts {
-    val title = "How much did you pay in costs when you sold the shares?"
-    val newTitle ="How much did you pay in costs when you sold the shares? - Calculate your Capital Gains Tax - GOV.UK"
+    val title = "Costs when you sold the shares"
+    val newTitle ="Costs when you sold the shares - Calculate your Capital Gains Tax - GOV.UK"
     val helpText = "This includes costs for stockbroker fees."
     val jointOwnership = "If you owned the shares with someone else, only enter your portion of the costs as agreed with your co-owner."
   }
 
   object SharesAcquisitionValue {
-    val title = "How much did you pay for the shares? - Calculate your Capital Gains Tax - GOV.UK"
-    val question = "How much did you pay for the shares?"
+    val title = "What you paid for the shares - Calculate your Capital Gains Tax - GOV.UK"
+    val question = "What you paid for the shares"
     val hintText = "If you owned them with someone else, only enter your share of the purchase."
     val bulletListTitle = "Put the market value of the shares instead if you:"
     val bulletListOne = "inherited them"


### PR DESCRIPTION
[DLS-9986](https://jira.tools.tax.service.gov.uk/browse/DLS-9986)

This PR delivers:

- content changes update for H1 in English and Welsh
- removal of the 'After this date use the original cost.' sentence in the body copy 
- simple fix to display line in 1 line on http://localhost:9704/calculate-your-capital-gains/resident/shares/value-before-legislation-start
- titles updated to be coherent with newly implemented content changes