### PR TITLE
DLS-9986: Delivery of content changes

### DIFF
--- a/app/connectors/CalculatorConnector.scala
+++ b/app/connectors/CalculatorConnector.scala
@@ -75,7 +75,7 @@ class CalculatorConnector @Inject()(http: DefaultHttpClient,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout),
+        Redirect(controllers.utils.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }
@@ -91,7 +91,7 @@ class CalculatorConnector @Inject()(http: DefaultHttpClient,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout),
+        Redirect(controllers.utils.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }
@@ -109,7 +109,7 @@ class CalculatorConnector @Inject()(http: DefaultHttpClient,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout),
+        Redirect(controllers.utils.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }
@@ -119,7 +119,7 @@ class CalculatorConnector @Inject()(http: DefaultHttpClient,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout),
+        Redirect(controllers.utils.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }

--- a/app/controllers/predicates/ValidActiveSession.scala
+++ b/app/controllers/predicates/ValidActiveSession.scala
@@ -32,7 +32,7 @@ trait ValidActiveSession  {
     def async(action: AsyncRequest): Action[AnyContent] = {
       Action.async { implicit request =>
         if (request.session.get(SessionKeys.sessionId).isEmpty) {
-          Future.successful(Redirect(controllers.utils.routes.TimeoutController.timeout))
+          Future.successful(Redirect(controllers.utils.routes.TimeoutController.timeout()))
         } else {
           action(request)
         }

--- a/app/services/SessionCacheService.scala
+++ b/app/services/SessionCacheService.scala
@@ -111,7 +111,7 @@ class SessionCacheService @Inject()(sessionRepository: SessionRepository)(implic
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout),
+        Redirect(controllers.utils.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }
@@ -131,7 +131,7 @@ class SessionCacheService @Inject()(sessionRepository: SessionRepository)(implic
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout),
+        Redirect(controllers.utils.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }
@@ -149,7 +149,7 @@ class SessionCacheService @Inject()(sessionRepository: SessionRepository)(implic
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.utils.routes.TimeoutController.timeout),
+        Redirect(controllers.utils.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }

--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -50,7 +50,7 @@
 @head = {
     @if(timeoutEnabled) {
         @hmrcTimeoutDialogHelper(
-            signOutUrl = controllers.utils.routes.TimeoutController.timeout.url
+            signOutUrl = controllers.utils.routes.TimeoutController.timeout().url
         )
     }
     <link rel="stylesheet" type="text/css" href ='@routes.Assets.versioned("stylesheets/cgt-calculator-resident-shares.css")'>

--- a/app/views/calculation/gain/acquisitionCosts.scala.html
+++ b/app/views/calculation/gain/acquisitionCosts.scala.html
@@ -37,7 +37,7 @@
 
     @errorSummary(acquisitionCostsForm.errors, Some("amount"))
 
-    <h1 class="govuk-heading-xl">@messages("calc.resident.shares.acquisitionCosts.question")</h1>
+    <h1 class="govuk-heading-xl">@messages("calc.resident.shares.acquisitionCosts.title")</h1>
 
     @form(action = controllers.routes.GainController.submitAcquisitionCosts) {
 

--- a/app/views/calculation/gain/acquisitionValue.scala.html
+++ b/app/views/calculation/gain/acquisitionValue.scala.html
@@ -41,7 +41,7 @@
 
     @errorSummary(acquisitionValueForm.errors)
 
-    <h1 class="govuk-heading-xl">@messages("calc.resident.shares.acquisitionValue.question")</h1>
+    <h1 class="govuk-heading-xl">@messages("calc.resident.shares.acquisitionValue.title")</h1>
 
     <p class="govuk-inset-text">@messages("calc.resident.shares.acquisitionValue.hintText")</p>
 

--- a/app/views/calculation/gain/disposalCosts.scala.html
+++ b/app/views/calculation/gain/disposalCosts.scala.html
@@ -38,7 +38,7 @@
 
     @errorSummary(disposalCostsForm.errors,Some("disposal-costs"))
 
-    <h1 class="govuk-heading-xl">@Messages("calc.resident.shares.disposalCosts.question")</h1>
+    <h1 class="govuk-heading-xl">@Messages("calc.resident.shares.disposalCosts.title")</h1>
 
     @form(action = controllers.routes.GainController.submitDisposalCosts){
 

--- a/app/views/calculation/gain/disposalValue.scala.html
+++ b/app/views/calculation/gain/disposalValue.scala.html
@@ -36,7 +36,7 @@
 
     @errorSummary(disposalValueForm.errors, Some("amount"))
 
-        <h1 class="govuk-heading-xl">@Messages("calc.resident.shares.disposalValue.question")</h1>
+        <h1 class="govuk-heading-xl">@Messages("calc.resident.shares.disposalValue.title")</h1>
 
         @form(action = controllers.routes.GainController.submitDisposalValue) {
 

--- a/app/views/calculation/gain/valueBeforeLegislationStart.scala.html
+++ b/app/views/calculation/gain/valueBeforeLegislationStart.scala.html
@@ -40,7 +40,7 @@
 ) {
     @errorSummary(valueBeforeLegislationStartForm.errors)
 
-    <h1 class="govuk-heading-xl">@messages("calc.resident.shares.valueBeforeLegislationStart.question")</h1>
+    <h1 class="govuk-heading-xl">@messages("calc.resident.shares.valueBeforeLegislationStart.title")</h1>
 
     <p class="govuk-body">@messages("calc.resident.shares.valueBeforeLegislationStart.information")</p>
 

--- a/app/views/calculation/gain/worthWhenInherited.scala.html
+++ b/app/views/calculation/gain/worthWhenInherited.scala.html
@@ -36,7 +36,7 @@
 
     @errorSummary(worthWhenInheritedForm.errors, Some("amount"))
 
-    <h1 class="govuk-heading-xl">@messages("calc.resident.shares.worthWhenInherited.question")</h1>
+    <h1 class="govuk-heading-xl">@messages("calc.resident.shares.worthWhenInherited.title")</h1>
 
     @form(action = controllers.routes.GainController.submitWorthWhenInherited) {
 

--- a/app/views/calculation/gain/worthWhenSoldForLess.scala.html
+++ b/app/views/calculation/gain/worthWhenSoldForLess.scala.html
@@ -37,7 +37,7 @@
 
     @errorSummary(worthWhenSoldForLessForm.errors, Some("amount"))
 
-    <h1 class="govuk-heading-l">@Messages("calc.resident.shares.worthWhenSoldForLess.question")</h1>
+    <h1 class="govuk-heading-l">@Messages("calc.resident.shares.worthWhenSoldForLess.title")</h1>
 
     <p class="govuk-body" id="information">@Messages("calc.resident.shares.worthWhenSoldForLess.informationText")</p>
 

--- a/app/views/calculation/income/personalAllowance.scala.html
+++ b/app/views/calculation/income/personalAllowance.scala.html
@@ -40,7 +40,7 @@
 
             @errorSummary(personalAllowanceForm.errors, Some("amount"))
 
-            <h1 class="govuk-heading-xl">@question</h1>
+            <h1 class="govuk-heading-xl">@messages("calc.resident.personalAllowance.title")</h1>
 
             <p class="govuk-body">@messages("calc.resident.personalAllowance.help")</p>
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,7 +6,7 @@
 GET         /assets/*file           @controllers.Assets.versioned(path="/public", file: Asset)
 
 #Session Timeout route
-GET         /session-timeout        @controllers.utils.TimeoutController.timeout
+GET         /session-timeout        @controllers.utils.TimeoutController.timeout()
 
 #Language Controller
 GET         /language/:lang         @controllers.CgtLanguageController.switchToLanguage(lang: String)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -68,26 +68,29 @@ calc.resident.personalAllowance.list.one = ennill mwy na £100,000
 calc.resident.personalAllowance.list.title = Yn y flwyddyn dreth {0}, £{1} oedd Lwfans Personol y DU, oni bai eich bod wedi gwneud y canlynol:
 calc.resident.personalAllowance.list.two = hawlio Lwfans Person Dall
 calc.resident.personalAllowance.list.three = hawlio Lwfans Priodasol
-calc.resident.personalAllowance.question = Yn y flwyddyn dreth {0}, faint oedd eich Lwfans Personol?
+calc.resident.personalAllowance.title = Lwfans Personol
 calc.resident.personalAllowance.error.mandatoryAmount = Nodwch beth oedd eich Lwfans Personol ar gyfer blwyddyn dreth {0}
 calc.resident.personalAllowance.error.invalidAmount = Mae''n rhaid i beth oedd eich Lwfans Personol ar gyfer blwyddyn dreth {0} fod yn y fformat cywir
 calc.resident.personalAllowance.error.minimumAmount = Mae''n rhaid i beth oedd eich Lwfans Personol ar gyfer blwyddyn dreth {0} fod yn 0 neu fwy
+calc.resident.personalAllowance.question = Yn y flwyddyn dreth {0}, faint oedd eich Lwfans Personol?
 
 calc.resident.saUser.errorSelect = Dewiswch a ydych chi''n rhan o''r drefn Hunanasesiad ar hyn o bryd
 calc.resident.saUser.title = Ydych chi''n rhan o''r drefn Hunanasesiad ar hyn o bryd?
 
 calc.resident.shares.acquisitionCosts.help = Mae hyn yn cynnwys costau ar gyfer ffioedd broceriaid stoc a Thollau Stamp.
 calc.resident.shares.acquisitionCosts.hintText = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi''ch cyfran chi o''r costau, fel y cytunwyd gyda''ch cydberchennog.
-calc.resident.shares.acquisitionCosts.question = Faint y gwnaethoch ei dalu o ran costau pan gawsoch y cyfranddaliadau?
+calc.resident.shares.acquisitionCosts.title = Y costau pan wnaethoch gael y cyfranddaliadau
 calc.resident.shares.acquisitionCosts.error.mandatoryAmount = Nodwch faint y gwnaethoch ei dalu o ran costau pan gawsoch y cyfranddaliadau
 calc.resident.shares.acquisitionCosts.error.invalidAmount = Mae''n rhaid i faint y gwnaethoch ei dalu o ran costau pan gawsoch y cyfranddaliadau fod yn y fformat cywir
 calc.resident.shares.acquisitionCosts.error.minimumAmount = Mae''n rhaid i faint y gwnaethoch ei dalu o ran costau pan gawsoch y cyfranddaliadau fod yn 0 neu fwy
+calc.resident.shares.acquisitionCosts.question = Faint y gwnaethoch ei dalu o ran costau pan gawsoch y cyfranddaliadau?
 
 calc.resident.shares.acquisitionValue.hintText = Os oeddech yn berchen arnynt gyda rhywun arall, dylech ond nodi''ch cyfran chi o''r pryniant.
-calc.resident.shares.acquisitionValue.question = Faint y gwnaethoch ei dalu am y cyfranddaliadau?
+calc.resident.shares.acquisitionValue.title = Yr hyn y a dalwyd gennych am y cyfranddaliadau
 calc.resident.shares.acquisitionValue.error.mandatoryAmount = Nodwch faint y gwnaethoch ei dalu am y cyfranddaliadau
 calc.resident.shares.acquisitionValue.error.invalidAmount = Mae''n rhaid i faint y gwnaethoch ei dalu am y cyfranddaliadau fod yn y fformat cywir
 calc.resident.shares.acquisitionValue.error.minimumAmount = Mae''n rhaid i faint y gwnaethoch ei dalu am y cyfranddaliadau fod yn 0 neu fwy
+calc.resident.shares.acquisitionValue.question = Faint y gwnaethoch ei dalu am y cyfranddaliadau?
 
 calc.resident.shares.currentIncome.helpText = Dylech gynnwys eich cyflog cyn treth, ac unrhyw beth arall rydych yn talu treth incwm arno, ond nid yr arian a wnaethoch wrth werthu''r cyfranddaliadau.
 calc.resident.currentIncome.question.error.mandatoryAmount = Nodwch eich incwm ar gyfer blwyddyn dreth {0}
@@ -99,10 +102,11 @@ calc.resident.shares.didYouInheritThem.question = A wnaethoch etifeddu''r cyfran
 
 calc.resident.shares.disposalCosts.helpText = Mae hyn yn cynnwys costau ar gyfer ffioedd broceriaid stoc.
 calc.resident.shares.disposalCosts.jointOwnership = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi''ch cyfran chi o''r costau, fel y cytunwyd gyda''ch cydberchennog.
-calc.resident.shares.disposalCosts.question = Faint y gwnaethoch ei dalu o ran costau wrth werthu''r cyfranddaliadau?
+calc.resident.shares.disposalCosts.title = Y costau pan wnaethoch werthu’r cyfranddaliadau
 calc.resident.shares.disposalCosts.error.mandatoryAmount = Nodwch faint y gwnaethoch ei dalu o ran costau pan wnaethoch werthu''r cyfranddaliadau
 calc.resident.shares.disposalCosts.error.invalidAmount = Mae''n rhaid i faint y gwnaethoch ei dalu o ran costau pan wnaethoch werthu''r cyfranddaliadau fod yn y fformat cywir
 calc.resident.shares.disposalCosts.error.minimumAmount = Mae''n rhaid i faint y gwnaethoch ei dalu o ran costau pan wnaethoch werthu''r cyfranddaliadau fod yn 0 neu fwy
+calc.resident.shares.disposalCosts.question = Faint y gwnaethoch ei dalu o ran costau wrth werthu''r cyfranddaliadau?
 
 calc.resident.shares.disposalDate.question = Pryd y gwnaethoch werthu''r cyfranddaliadau, neu eu rhoi i ffwrdd?
 disposalDate.error.required                = Nodwch y diwrnod, y mis, a’r flwyddyn y gwnaethoch werthu’r cyfranddaliadau, neu eu rhoi i ffwrdd
@@ -126,10 +130,11 @@ disposalDate.error.notReal.year            = Nodwch flwyddyn go iawn ar gyfer y 
 disposalDate.error.range.min               = Mae’n rhaid i’r dyddiad y gwnaethoch werthu’r cyfranddaliadau, neu eu rhoi i ffwrdd, fod ar ôl {0}
 
 calc.resident.shares.disposalValue.jointOwnership = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi''ch cyfran chi o''r pris gwerthu.
-calc.resident.shares.disposalValue.question = Am faint y gwnaethoch werthu''r cyfranddaliadau?
+calc.resident.shares.disposalValue.title = Gwerth y cyfranddaliadau pan gawsant eu gwerthu
 calc.resident.shares.disposalValue.error.mandatoryAmount = Nodwch faint y gwnaethoch werthu''r cyfranddaliadau amdano
 calc.resident.shares.disposalValue.error.invalidAmount = Mae''n rhaid i faint y gwnaethoch werthu''r cyfranddaliadau amdano fod yn y fformat cywir
 calc.resident.shares.disposalValue.error.minimumAmount = Mae''n rhaid i faint y gwnaethoch werthu''r cyfranddaliadau amdano fod yn 0 neu fwy
+calc.resident.shares.disposalValue.question = Am faint y gwnaethoch werthu''r cyfranddaliadau?
 
 calc.resident.shares.outsideTaxYears.message.tooEarly = Gallwch ddefnyddio''r gyfrifiannell hon os ydych wedi gwerthu cyfranddaliadau ers 5 Ebrill 2015.
 
@@ -142,25 +147,28 @@ calc.resident.shares.sellForLess.question = A wnaethoch werthu''r cyfranddaliada
 
 calc.resident.shares.valueBeforeLegislationStart.help = Cewch wybodaeth am y prisiad o''r gyfnewidfa stoc neu siaradwch â''ch brocer stoc neu reolwr eich cronfa.
 calc.resident.shares.valueBeforeLegislationStart.hintText = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi gwerth eich cyfran chi o''r cyfranddaliadau.
-calc.resident.shares.valueBeforeLegislationStart.information = Os cawsoch eich cyfranddaliadau cyn 31 Mawrth 1982, defnyddiwch y gwerth marchnadol ar 31 Mawrth 1982 i gyfrifo''ch Treth Enillion Cyfalaf. Ar ôl y dyddiad hwn, defnyddiwch y gost wreiddiol.
-calc.resident.shares.valueBeforeLegislationStart.question = Beth oedd gwerth y cyfranddaliadau ar 31 Mawrth 1982?
+calc.resident.shares.valueBeforeLegislationStart.information = Os cawsoch eich cyfranddaliadau cyn 31 Mawrth 1982, defnyddiwch y gwerth marchnadol ar 31 Mawrth 1982 i gyfrifo''ch Treth Enillion Cyfalaf.
+calc.resident.shares.valueBeforeLegislationStart.title = Roeddech yn berchen ar y cyfranddaliadau cyn 1 Ebrill 1982
 calc.resident.shares.valueBeforeLegislationStart.error.mandatoryAmount = Nodwch beth oedd gwerth y cyfranddaliadau ar 31 Mawrth 1982
 calc.resident.shares.valueBeforeLegislationStart.error.invalidAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau ar 31 Mawrth 1982 fod yn y fformat cywir
 calc.resident.shares.valueBeforeLegislationStart.error.minimumAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau ar 31 Mawrth 1982 fod yn 0 neu fwy
+calc.resident.shares.valueBeforeLegislationStart.question = Beth oedd gwerth y cyfranddaliadau ar 31 Mawrth 1982?
 
 calc.resident.shares.worthWhenInherited.help = Defnyddiwch wybodaeth o''r gyfnewidfa stoc neu siaradwch â''ch brocer stoc neu reolwr eich cronfa.
 calc.resident.shares.worthWhenInherited.hintText = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi''r gwerth marchnadol ar gyfer eich cyfran chi o''r cyfranddaliadau.
-calc.resident.shares.worthWhenInherited.question = Beth oedd gwerth y cyfranddaliadau pan wnaethoch eu hetifeddu?
+calc.resident.shares.worthWhenInherited.title = Gwerth y cyfranddaliadau pan gawsant eu hetifeddu
 calc.resident.shares.worthWhenInherited.error.mandatoryAmount = Nodwch beth oedd gwerth y cyfranddaliadau pan wnaethoch eu hetifeddu
 calc.resident.shares.worthWhenInherited.error.invalidAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau pan wnaethoch eu hetifeddu fod yn y fformat cywir
 calc.resident.shares.worthWhenInherited.error.minimumAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau pan wnaethoch eu hetifeddu fod yn 0 neu fwy
+calc.resident.shares.worthWhenInherited.question = Beth oedd gwerth y cyfranddaliadau pan wnaethoch eu hetifeddu?
 
 calc.resident.shares.worthWhenSoldForLess.informationText = Cewch wybodaeth o''r gyfnewidfa stoc neu siaradwch â''ch brocer stoc neu reolwr eich cronfa.
 calc.resident.shares.worthWhenSoldForLess.jointOwnershipText = Os oeddech yn berchen ar y cyfranddaliadau gyda rhywun arall, dylech ond nodi gwerth eich cyfran chi o''r cyfranddaliadau.
-calc.resident.shares.worthWhenSoldForLess.question = Beth oedd gwerth y cyfranddaliadau pan wnaethoch eu gwerthu?
+calc.resident.shares.worthWhenSoldForLess.title = Y gwerth marchnadol pan gawsant eu gwerthu
 calc.resident.shares.worthWhenSoldForLess.error.mandatoryAmount = Nodwch beth oedd gwerth y cyfranddaliadau pan wnaethoch eu gwerthu
 calc.resident.shares.worthWhenSoldForLess.error.invalidAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau pan wnaethoch eu gwerthu fod yn y fformat cywir
 calc.resident.shares.worthWhenSoldForLess.error.minimumAmount = Mae''n rhaid i beth oedd gwerth y cyfranddaliadau pan wnaethoch eu gwerthu fod yn 0 neu fwy
+calc.resident.shares.worthWhenSoldForLess.question = Beth oedd gwerth y cyfranddaliadau pan wnaethoch eu gwerthu?
 
 calc.resident.summary.annualExemptAmountHelp = Gallwch ddefnyddio hyn i ostwng eich treth os ydych yn gwerthu rhywbeth arall a gwmpesir gan Dreth Enillion Cyfalaf yn yr un flwyddyn dreth.
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -96,7 +96,7 @@ calc.resident.currentIncome.questionCurrentYear.error.invalidAmount = How much y
 calc.resident.currentIncome.questionCurrentYear.error.minimumAmount = How much you expect your income to be in this year must be £0 or more
 
 ## Personal Allowance messages
-calc.resident.personalAllowance.question = In the {0} tax year, what was your Personal Allowance?
+calc.resident.personalAllowance.title = Personal Allowance
 calc.resident.personalAllowance.list.title = In the tax year {0} the UK Personal Allowance was £{1} unless you:
 calc.resident.personalAllowance.help = This is the amount of your income that you do not pay tax on.
 calc.resident.personalAllowance.list.one = earned more than £100,000
@@ -108,6 +108,7 @@ calc.resident.personalAllowance.currentYearQuestion = How much is your Personal 
 calc.resident.personalAllowance.error.mandatoryAmount = Enter what your Personal Allowance was for the {0} tax year
 calc.resident.personalAllowance.error.invalidAmount = Your Personal Allowance for the {0} tax year must be in the correct format
 calc.resident.personalAllowance.error.minimumAmount = Your Personal Allowance for the {0} tax year must be 0 or more
+calc.resident.personalAllowance.question = In the {0} tax year, what was your Personal Allowance?
 
 #####################################################################################x##########
 ## Resident Shares messages ##
@@ -136,40 +137,44 @@ disposalDate.error.notReal.year            = Enter a real year for when you sold
 disposalDate.error.range.min               = The date you sold or gave away the shares must be after {0}
 
 ## Disposal Value messages
-calc.resident.shares.disposalValue.question = How much did you sell the shares for?
+calc.resident.shares.disposalValue.title = Shares value when sold
 calc.resident.shares.disposalValue.jointOwnership = If you owned the shares with someone else, only enter your portion of the sale value.
 calc.resident.shares.disposalValue.error.mandatoryAmount = Enter how much you sold the shares for
 calc.resident.shares.disposalValue.error.invalidAmount = How much you sold the shares for must be in the correct format
 calc.resident.shares.disposalValue.error.minimumAmount = How much you sold the shares for must be 0 or more
+calc.resident.shares.disposalValue.question = How much did you sell the shares for?
 
 ## Sell for Less messages
 calc.resident.shares.sellForLess.question = Did you sell the shares for less than they were worth to help the buyer?
 calc.resident.shares.sellForLess.noSelectError = Tell us if you sold the shares for less than they were worth to help the buyer.
 
 ## Worth When Sold For Less messages
-calc.resident.shares.worthWhenSoldForLess.question = What were the shares worth when you sold them?
+calc.resident.shares.worthWhenSoldForLess.title = Market value when sold
 calc.resident.shares.worthWhenSoldForLess.informationText = Get information from the stock exchange or talk to your stockbroker or fund manager.
 calc.resident.shares.worthWhenSoldForLess.jointOwnershipText = If you owned the shares with someone else, only enter the value of your portion of the shares.
 calc.resident.shares.worthWhenSoldForLess.error.mandatoryAmount = Enter how much the shares were worth when you sold them
 calc.resident.shares.worthWhenSoldForLess.error.invalidAmount = How much the shares were worth when you sold them must be in the correct format
 calc.resident.shares.worthWhenSoldForLess.error.minimumAmount = How much the shares were worth when you sold them must be 0 or more
+calc.resident.shares.worthWhenSoldForLess.question = What were the shares worth when you sold them?
 
 ## Disposal Costs messages
-calc.resident.shares.disposalCosts.question = How much did you pay in costs when you sold the shares?
+calc.resident.shares.disposalCosts.title = Costs when you sold the shares
 calc.resident.shares.disposalCosts.helpText = This includes costs for stockbroker fees.
 calc.resident.shares.disposalCosts.jointOwnership = If you owned the shares with someone else, only enter your portion of the costs as agreed with your co-owner.
 calc.resident.shares.disposalCosts.error.mandatoryAmount = Enter how much you paid in costs when you sold the shares
 calc.resident.shares.disposalCosts.error.invalidAmount = How much you paid in costs when you sold the shares must be in the correct format
 calc.resident.shares.disposalCosts.error.minimumAmount = How much you paid in costs when you sold the shares must be 0 or more
+calc.resident.shares.disposalCosts.question = How much did you pay in costs when you sold the shares?
 
 ## Worth On messages
-calc.resident.shares.valueBeforeLegislationStart.question = What were the shares worth on 31 March 1982?
-calc.resident.shares.valueBeforeLegislationStart.information = If you had your shares before 31 March 1982, use the market value on 31 March 1982 to work out your Capital Gains Tax. After this date, use the original cost.
+calc.resident.shares.valueBeforeLegislationStart.title = You owned the shares before 1 April 1982
+calc.resident.shares.valueBeforeLegislationStart.information = If you had your shares before 31 March 1982, use the market value on 31 March 1982 to work out your Capital Gains Tax.
 calc.resident.shares.valueBeforeLegislationStart.help = Get valuation information from the stock exchange or talk to your stockbroker or fund manager.
 calc.resident.shares.valueBeforeLegislationStart.hintText = If you owned the shares with someone else, only enter the value of your portion of the shares.
 calc.resident.shares.valueBeforeLegislationStart.error.mandatoryAmount = Enter what the shares were worth on 31 March 1982
 calc.resident.shares.valueBeforeLegislationStart.error.invalidAmount = What the shares were worth on 31 March 1982 must be in the correct format
 calc.resident.shares.valueBeforeLegislationStart.error.minimumAmount = What the shares were worth on 31 March 1982 must be 0 or more
+calc.resident.shares.valueBeforeLegislationStart.question = What were the shares worth on 31 March 1982?
 
 ## Owner Before Legislation Start Messages
 calc.resident.shares.ownerBeforeLegislationStart.title = Did you own the shares before 1 April 1982?
@@ -177,31 +182,34 @@ calc.resident.shares.ownerBeforeLegislationStart.help = If you had your shares b
 calc.resident.shares.ownerBeforeLegislationStart.noSelectError = Tell us if you owned the shares before 1 April 1982
 
 ## Worth When Inherited
-calc.resident.shares.worthWhenInherited.question = What were the shares worth when you inherited them?
+calc.resident.shares.worthWhenInherited.title = Shares value when inherited
 calc.resident.shares.worthWhenInherited.help = Use information from the stock exchange or talk to your stockbroker or fund manager.
 calc.resident.shares.worthWhenInherited.hintText = If you owned the shares with someone else, only enter the market value for your portion of the shares.
 calc.resident.shares.worthWhenInherited.error.mandatoryAmount = Enter what the shares were worth when you inherited them
 calc.resident.shares.worthWhenInherited.error.invalidAmount = How much the shares were worth when you inherited them must be in the correct format
 calc.resident.shares.worthWhenInherited.error.minimumAmount = What the shares were worth when you inherited them must be 0 or more
+calc.resident.shares.worthWhenInherited.question = What were the shares worth when you inherited them?
 
 ## Inherited Shares Messages
 calc.resident.shares.didYouInheritThem.errorSelect = Tell us if you inherited the shares
 calc.resident.shares.didYouInheritThem.question = Did you inherit the shares?
 
 ## Acquisition Value messages
-calc.resident.shares.acquisitionValue.question = How much did you pay for the shares?
+calc.resident.shares.acquisitionValue.title = What you paid for the shares
 calc.resident.shares.acquisitionValue.hintText = If you owned them with someone else, only enter your share of the purchase.
 calc.resident.shares.acquisitionValue.error.mandatoryAmount = Enter how much you paid for the shares
 calc.resident.shares.acquisitionValue.error.invalidAmount = How much you paid for the shares must be in the correct format
 calc.resident.shares.acquisitionValue.error.minimumAmount = How much you paid for the shares must be 0 or more
+calc.resident.shares.acquisitionValue.question = How much did you pay for the shares?
 
 ## Acquisition Costs messages
-calc.resident.shares.acquisitionCosts.question = How much did you pay in costs when you got the shares?
+calc.resident.shares.acquisitionCosts.title = Costs when you got the shares
 calc.resident.shares.acquisitionCosts.help = This includes costs for stockbroker fees and Stamp Duty.
 calc.resident.shares.acquisitionCosts.hintText = If you owned the shares with someone else, only enter your portion of the costs as agreed with your co-owner.
 calc.resident.shares.acquisitionCosts.error.mandatoryAmount = Enter how much you paid in costs when you got the shares
 calc.resident.shares.acquisitionCosts.error.invalidAmount = How much you paid in costs when you got the shares must be in the correct format
 calc.resident.shares.acquisitionCosts.error.minimumAmount = How much you paid in costs when you got the shares must be 0 or more
+calc.resident.shares.acquisitionCosts.question = How much did you pay in costs when you got the shares?
 
 ## Final Summary messages
 calc.summary.cgtToPay = Capital Gains Tax to pay for the {0} tax year

--- a/test/assets/MessageLookup.scala
+++ b/test/assets/MessageLookup.scala
@@ -408,20 +408,22 @@ object MessageLookup {
       }
 
       object ValueBeforeLegislationStart {
-        val title = "What were the shares worth on 31 March 1982? - Calculate your Capital Gains Tax - GOV.UK"
+        val title = s"$pageTitle - Calculate your Capital Gains Tax - GOV.UK"
         val question = "What were the shares worth on 31 March 1982?"
         val information = "If you had your shares before 31 March 1982, use the market value on 31 March 1982 to work " +
           "out your Capital Gains Tax. After this date, use the original cost."
         val helpText = "Get valuation information from the stock exchange or talk to your stockbroker or fund manager."
         val hintText = "If you owned the shares with someone else, only enter the value of your portion of the shares."
+        val pageTitle = "You owned the shares before 1 April 1982"
 
       }
 
       object DisposalValue {
-        val title = "How much did you sell the shares for? - Calculate your Capital Gains Tax - GOV.UK"
+        val title = s"$pageTitle - Calculate your Capital Gains Tax - GOV.UK"
         val question = "How much did you sell the shares for?"
         val jointOwnership = "If you owned the shares with someone else, only enter your portion of the sale value."
         val nonValidDate = "Enter a real date Enter a date that is after 6 4 2015"
+        val pageTitle = "Shares value when sold"
       }
 
       //############ Owner Before Legislation Start messages.en #################//
@@ -445,18 +447,20 @@ object MessageLookup {
 
       //############ Worth When Inherited messages.en #################//
       object WorthWhenInherited {
-        val title = "What were the shares worth when you inherited them? - Calculate your Capital Gains Tax - GOV.UK"
+        val title = s"$pageTitle - Calculate your Capital Gains Tax - GOV.UK"
         val question = "What were the shares worth when you inherited them?"
         val helpText = "Use information from the stock exchange or talk to your stockbroker or fund manager."
         val hintText = "If you owned the shares with someone else, only enter the market value for your portion of the shares."
+        val pageTitle = "Shares value when inherited"
       }
 
       //############ Worth When Sold For Less messages.en #################//
       object WorthWhenSoldForLess {
-        val title = "What were the shares worth when you sold them? - Calculate your Capital Gains Tax - GOV.UK"
+        val title = s"$pageTitle - Calculate your Capital Gains Tax - GOV.UK"
         val question = "What were the shares worth when you sold them?"
         val informationText = "Get information from the stock exchange or talk to your stockbroker or fund manager."
         val jointOwnershipText = "If you owned the shares with someone else, only enter the value of your portion of the shares."
+        val pageTitle = "Market value when sold"
       }
 
     }
@@ -674,7 +678,8 @@ object MessageLookup {
   //Personal Allowance messages.en
   object PersonalAllowance {
     def question(input: String): String = s"In the $input tax year, what was your Personal Allowance?"
-    def title(input: String): String = s"In the $input tax year, what was your Personal Allowance? - Calculate your Capital Gains Tax - GOV.UK"
+    val title = s"$pageTitle - Calculate your Capital Gains Tax - GOV.UK"
+    val pageTitle = "Personal Allowance"
     val link = "Income tax rates and Personal Allowances"
     val linkText = "Find out more about"
     val help = "This is the amount of your income that you do not pay tax on."
@@ -708,26 +713,29 @@ object MessageLookup {
   }
 
   object SharesAcquisitionCosts {
-    val title = "How much did you pay in costs when you got the shares? - Calculate your Capital Gains Tax - GOV.UK"
+    val title = s"$pageTitle - Calculate your Capital Gains Tax - GOV.UK"
     val question = "How much did you pay in costs when you got the shares?"
     val helpText = "This includes costs for stockbroker fees and Stamp Duty."
     val hintText = "If you owned the shares with someone else, only enter your portion of the costs as agreed with your co-owner."
+    val pageTitle = "Costs when you got the shares"
   }
 
   object SharesDisposalCosts {
     val title = "How much did you pay in costs when you sold the shares?"
-    val newTitle ="How much did you pay in costs when you sold the shares? - Calculate your Capital Gains Tax - GOV.UK"
+    val newTitle =s"$pageTitle - Calculate your Capital Gains Tax - GOV.UK"
     val helpText = "This includes costs for stockbroker fees."
     val jointOwnership = "If you owned the shares with someone else, only enter your portion of the costs as agreed with your co-owner."
+    val pageTitle = "Costs when you sold the shares"
   }
 
   object SharesAcquisitionValue {
-    val title = "How much did you pay for the shares? - Calculate your Capital Gains Tax - GOV.UK"
+    val title = s"$pageTitle - Calculate your Capital Gains Tax - GOV.UK"
     val question = "How much did you pay for the shares?"
     val hintText = "If you owned them with someone else, only enter your share of the purchase."
     val bulletListTitle = "Put the market value of the shares instead if you:"
     val bulletListOne = "inherited them"
     val bulletListTwo = "owned them before 1 April 1982"
+    val pageTitle = "What you paid for the shares"
   }
 
   object SharesOtherDisposals {

--- a/test/controllers/IncomeControllerSpec/PersonalAllowanceActionSpec.scala
+++ b/test/controllers/IncomeControllerSpec/PersonalAllowanceActionSpec.scala
@@ -104,7 +104,7 @@ class PersonalAllowanceActionSpec extends CommonPlaySpec with WithCommonFakeAppl
       }
 
       "display the Personal Allowance view" in {
-        Jsoup.parse(bodyOf(result)).title shouldBe messages.title("2015 to 2016")
+        Jsoup.parse(bodyOf(result)).title shouldBe messages.title
       }
     }
 
@@ -124,7 +124,7 @@ class PersonalAllowanceActionSpec extends CommonPlaySpec with WithCommonFakeAppl
       }
 
       "display the Personal Allowance view" in {
-        Jsoup.parse(bodyOf(result)).title shouldBe messages.title("2015 to 2016")
+        Jsoup.parse(bodyOf(result)).title shouldBe messages.title
       }
     }
   }
@@ -178,7 +178,7 @@ class PersonalAllowanceActionSpec extends CommonPlaySpec with WithCommonFakeAppl
       }
 
       "render the personal allowance page" in {
-        doc.title() shouldEqual "Error: " + messages.title("2015 to 2016")
+        doc.title() shouldEqual "Error: " + messages.title
       }
     }
   }

--- a/test/controllers/IncomeControllerSpec/PersonalAllowanceActionSpec.scala
+++ b/test/controllers/IncomeControllerSpec/PersonalAllowanceActionSpec.scala
@@ -32,6 +32,7 @@ import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.Application
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.Helpers._
 import services.SessionCacheService
@@ -42,15 +43,15 @@ import scala.concurrent.Future
 class PersonalAllowanceActionSpec extends CommonPlaySpec with WithCommonFakeApplication with FakeRequestHelper with MockitoSugar {
 
   implicit lazy val actorSystem = ActorSystem()
-  val mockCalcConnector = mock[CalculatorConnector]
-  val mockSessionCacheService = mock[SessionCacheService]
-  implicit val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
-  implicit val mockApplication = fakeApplication
-  val mockMCC = fakeApplication.injector.instanceOf[MessagesControllerComponents]
-  val personalAllowanceForm = fakeApplication.injector.instanceOf[PersonalAllowanceForm]
-  val personalAllowanceView = fakeApplication.injector.instanceOf[personalAllowance]
-  val currentIncomeForm = fakeApplication.injector.instanceOf[CurrentIncomeForm]
-  val currentIncomeView = fakeApplication.injector.instanceOf[currentIncome]
+  val mockCalcConnector: CalculatorConnector = mock[CalculatorConnector]
+  val mockSessionCacheService: SessionCacheService = mock[SessionCacheService]
+  implicit val mockConfig: ApplicationConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
+  implicit val mockApplication: Application = fakeApplication
+  val mockMCC: MessagesControllerComponents = fakeApplication.injector.instanceOf[MessagesControllerComponents]
+  val personalAllowanceForm: PersonalAllowanceForm = fakeApplication.injector.instanceOf[PersonalAllowanceForm]
+  val personalAllowanceView: personalAllowance = fakeApplication.injector.instanceOf[personalAllowance]
+  val currentIncomeForm: CurrentIncomeForm = fakeApplication.injector.instanceOf[CurrentIncomeForm]
+  val currentIncomeView: currentIncome = fakeApplication.injector.instanceOf[currentIncome]
 
   def setupTarget(getData: Option[PersonalAllowanceModel],
                   maxPersonalAllowance: Option[BigDecimal] = Some(BigDecimal(11100)),

--- a/test/views/calculation/gain/AcquisitionCostsViewSpec.scala
+++ b/test/views/calculation/gain/AcquisitionCostsViewSpec.scala
@@ -22,11 +22,12 @@ import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
 import forms.AcquisitionCostsForm._
 import org.jsoup.Jsoup
+import play.api.i18n.Messages
 import play.api.mvc.MessagesControllerComponents
 import views.html.calculation.gain.acquisitionCosts
 
 class AcquisitionCostsViewSpec extends CommonPlaySpec with WithCommonFakeApplication with FakeRequestHelper {
-  implicit lazy val mockMessage = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+  implicit lazy val mockMessage: Messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
 
   val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
   val acquisitionCostsView = fakeApplication.injector.instanceOf[acquisitionCosts]

--- a/test/views/calculation/gain/AcquisitionValueViewSpec.scala
+++ b/test/views/calculation/gain/AcquisitionValueViewSpec.scala
@@ -22,11 +22,12 @@ import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
 import forms.AcquisitionValueForm._
 import org.jsoup.Jsoup
+import play.api.i18n.Messages
 import play.api.mvc.MessagesControllerComponents
 import views.html.calculation.gain.acquisitionValue
 
 class AcquisitionValueViewSpec extends CommonPlaySpec with WithCommonFakeApplication with FakeRequestHelper {
-  implicit lazy val mockMessage = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+  implicit lazy val mockMessage: Messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
 
   val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
   val acquisitionValueView = fakeApplication.injector.instanceOf[acquisitionValue]

--- a/test/views/calculation/gain/DisposalCostsViewSpec.scala
+++ b/test/views/calculation/gain/DisposalCostsViewSpec.scala
@@ -22,11 +22,12 @@ import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
 import forms.DisposalCostsForm._
 import org.jsoup.Jsoup
+import play.api.i18n.Messages
 import play.api.mvc.MessagesControllerComponents
 import views.html.calculation.gain.disposalCosts
 
 class DisposalCostsViewSpec extends CommonPlaySpec with WithCommonFakeApplication with FakeRequestHelper {
-  implicit lazy val mockMessage = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+  implicit lazy val mockMessage: Messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
 
   val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
   val disposalCostsView = fakeApplication.injector.instanceOf[disposalCosts

--- a/test/views/calculation/gain/ValueBeforeLegislationStartViewSpec.scala
+++ b/test/views/calculation/gain/ValueBeforeLegislationStartViewSpec.scala
@@ -23,11 +23,12 @@ import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
 import forms.ValueBeforeLegislationStartForm._
 import org.jsoup.Jsoup
+import play.api.i18n.Messages
 import play.api.mvc.MessagesControllerComponents
 import views.html.calculation.gain.valueBeforeLegislationStart
 
 class ValueBeforeLegislationStartViewSpec extends CommonPlaySpec with WithCommonFakeApplication with FakeRequestHelper {
-  implicit lazy val mockMessage = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+  implicit lazy val mockMessage: Messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
 
   val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
   val valueBeforeLegislationStartView = fakeApplication.injector.instanceOf[valueBeforeLegislationStart]

--- a/test/views/calculation/gain/WorthWhenSoldForLessViewSpec.scala
+++ b/test/views/calculation/gain/WorthWhenSoldForLessViewSpec.scala
@@ -23,11 +23,12 @@ import config.ApplicationConfig
 import controllers.helpers.FakeRequestHelper
 import forms.WorthWhenSoldForLessForm._
 import org.jsoup.Jsoup
+import play.api.i18n.Messages
 import play.api.mvc.MessagesControllerComponents
 import views.html.calculation.gain.worthWhenSoldForLess
 
 class WorthWhenSoldForLessViewSpec extends CommonPlaySpec with WithCommonFakeApplication with FakeRequestHelper {
-  implicit lazy val mockMessage = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+  implicit lazy val mockMessage: Messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
 
   val mockConfig = fakeApplication.injector.instanceOf[ApplicationConfig]
   val worthWhenSoldForLessView = fakeApplication.injector.instanceOf[worthWhenSoldForLess]

--- a/test/views/calculation/income/PersonalAllowanceViewSpec.scala
+++ b/test/views/calculation/income/PersonalAllowanceViewSpec.scala
@@ -54,8 +54,8 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
         doc.charset().toString shouldBe "UTF-8"
       }
 
-      s"have a title ${messages.title("2015 to 2016")}" in {
-        doc.title() shouldBe messages.title("2015 to 2016")
+      s"have a title ${messages.title}" in {
+        doc.title() shouldBe messages.title
       }
 
       "have a navTitle of Calculate your Capital Gains Tax" in {
@@ -220,8 +220,8 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
       val splitYear = nextTaxYear.split("/")
       val nextTaxYearFormatted = splitYear(0) + " to " + splitYear(0).substring(0, 2) + splitYear(1)
 
-      s"have a title ${messages.title(s"$nextTaxYearFormatted")}" in {
-        doc.title() shouldBe messages.title(s"$nextTaxYearFormatted")
+      s"have a title ${messages.title}" in {
+        doc.title() shouldBe messages.title
       }
 
       s"have the page heading '${messages.title}'" in {

--- a/test/views/calculation/income/PersonalAllowanceViewSpec.scala
+++ b/test/views/calculation/income/PersonalAllowanceViewSpec.scala
@@ -81,8 +81,8 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
         doc.getElementsByClass("hmrc-header__service-name hmrc-header__service-name--linked").attr("href") shouldEqual "/calculate-your-capital-gains/resident/shares/disposal-date"
       }
 
-      s"have the page heading '${messages.question("2015 to 2016")}'" in {
-        doc.select("h1").text shouldBe messages.question("2015 to 2016")
+      s"have the page heading '${messages.title}'" in {
+        doc.select("h1").text shouldBe messages.title
       }
 
       s"have the help text ${messages.help}" in {
@@ -224,12 +224,12 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
         doc.title() shouldBe messages.title(s"$nextTaxYearFormatted")
       }
 
-      s"have the page heading '${messages.question(s"$nextTaxYearFormatted")}'" in {
-        h1Tag.text shouldBe messages.question(s"$nextTaxYearFormatted")
+      s"have the page heading '${messages.title}'" in {
+        h1Tag.text shouldBe messages.title
       }
 
-      s"have a legend for an input with text ${messages.question(s"$nextTaxYearFormatted")}" in {
-        doc.body.getElementsByClass("govuk-heading-xl").text() shouldEqual messages.question(s"$nextTaxYearFormatted")
+      s"have a legend for an input with text ${messages.title}" in {
+        doc.body.getElementsByClass("govuk-heading-xl").text() shouldEqual messages.title
       }
     }
 

--- a/test/views/helpers/CheckYourAnswersPartialViewSpec.scala
+++ b/test/views/helpers/CheckYourAnswersPartialViewSpec.scala
@@ -26,13 +26,13 @@ import controllers.helpers.FakeRequestHelper
 import controllers.routes
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.i18n.Lang
+import play.api.i18n.{Lang, Messages}
 import play.api.mvc.MessagesControllerComponents
 import play.twirl.api.HtmlFormat
 import views.html.playHelpers.checkYourAnswersPartial
 
 class CheckYourAnswersPartialViewSpec extends CommonPlaySpec with WithCommonFakeApplication with FakeRequestHelper {
-  implicit lazy val mockMessage = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
+  implicit lazy val mockMessage: Messages = fakeApplication.injector.instanceOf[MessagesControllerComponents].messagesApi.preferred(fakeRequest)
   val fakeLang: Lang = Lang("en")
   val checkYourAnswersPartialView = fakeApplication.injector.instanceOf[checkYourAnswersPartial]
 


### PR DESCRIPTION
[DLS-9986](https://jira.tools.tax.service.gov.uk/browse/DLS-9986)
Hence the instructions in the ticket were wrong, I have created another PR to address the required content changes.
I have closed the https://github.com/hmrc/cgt-calculator-resident-shares-frontend/pull/191.

This PR delivers:

- content changes update for only H1 in English and Welsh. Label remained unchanged, so still previous H1 is displayed in the labels.
- removal of the 'After this date use the original cost.' sentence in the body copy 
- simple fix to display line in 1 line on http://localhost:9704/calculate-your-capital-gains/resident/shares/value-before-legislation-start
- titles updated to be coherent with newly implemented content changes
