### PR TITLE
DLS-9986: Size fix for one of H1s [l -> xl]

### DIFF
--- a/app/views/calculation/gain/worthWhenSoldForLess.scala.html
+++ b/app/views/calculation/gain/worthWhenSoldForLess.scala.html
@@ -37,7 +37,7 @@
 
     @errorSummary(worthWhenSoldForLessForm.errors, Some("amount"))
 
-    <h1 class="govuk-heading-l">@Messages("calc.resident.shares.worthWhenSoldForLess.title")</h1>
+    <h1 class="govuk-heading-xl">@Messages("calc.resident.shares.worthWhenSoldForLess.title")</h1>
 
     <p class="govuk-body" id="information">@Messages("calc.resident.shares.worthWhenSoldForLess.informationText")</p>
 

--- a/test/views/calculation/gain/WorthWhenSoldForLessViewSpec.scala
+++ b/test/views/calculation/gain/WorthWhenSoldForLessViewSpec.scala
@@ -67,8 +67,8 @@ class WorthWhenSoldForLessViewSpec extends CommonPlaySpec with WithCommonFakeApp
         heading.text shouldBe messages.h1
       }
 
-      "have the govuk-heading-l class" in {
-        heading.hasClass("govuk-heading-l") shouldEqual true
+      "have the govuk-heading-xl class" in {
+        heading.hasClass("govuk-heading-xl") shouldEqual true
       }
     }
 


### PR DESCRIPTION
During delivery of [DLS-9986](https://jira.tools.tax.service.gov.uk/browse/DLS-9986) it has been observed that one of the H1s is smaller than the rest. The fix is simple and since it's Friday and we can't release, I'm doing it now.

![image](https://github.com/hmrc/cgt-calculator-resident-shares-frontend/assets/112881943/af288c7d-cc81-4ad4-a3ee-ba94ed25693d)
